### PR TITLE
Use NuGet reference instead of project reference

### DIFF
--- a/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
+++ b/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
@@ -11,11 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ActiveLogin.Identity.Swedish" Version="0.1.19" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ActiveLogin.Identity.Swedish\ActiveLogin.Identity.Swedish.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Use NuGet reference for dependent projects now that they are available on NuGet.