### PR TITLE
Add Luhn checksum validation and tests

### DIFF
--- a/src/ActiveLogin.Identity.Swedish/LuhnChecksum.cs
+++ b/src/ActiveLogin.Identity.Swedish/LuhnChecksum.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ActiveLogin.Identity.Swedish
+{
+    /// <summary>
+    /// Implementation of algorithm descirbed in https://en.wikipedia.org/wiki/Luhn_algorithm
+    /// </summary>
+    internal class LuhnChecksum
+    {
+        public static int GetChecksum(string digits)
+        {
+            var ints = digits.Select(x => int.Parse(x.ToString()));
+            return GetChecksum(ints);
+        }
+
+        public static int GetChecksum(IEnumerable<int> digits)
+        {
+            var luhnSum = digits.Reverse()
+                .Select((digit, index) => index % 2 == 0 ? digit * 2 : digit)
+                .Reverse()
+                .Select(digit => digit > 9 ? digit - 9 : digit)
+                .Sum();
+
+            return (luhnSum * 9) % 10;
+        }
+    }
+}

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -103,6 +103,11 @@ namespace ActiveLogin.Identity.Swedish
             {
                 throw new ArgumentOutOfRangeException(nameof(serialNumber), serialNumber, "Invalid serial number. Must be in the range 0 to 999.");
             }
+
+            if (!validator.ChecksumIsValid())
+            {
+                throw new ArgumentException("Invalid checksum.", nameof(checksum));
+            }
         }
 
         /// <summary>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberValidator.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberValidator.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ActiveLogin.Identity.Swedish
 {
@@ -21,7 +23,7 @@ namespace ActiveLogin.Identity.Swedish
             SerialNumber = serialNumber;
             Checksum = checksum;
         }
-        
+
         public bool DayIsValidCoOrdinationNumber()
         {
             var daysWithoutCoOrdinationNumberDaysAdded = Day - CoOrdinationNumberDaysAdded;
@@ -52,6 +54,16 @@ namespace ActiveLogin.Identity.Swedish
         public bool SerialNumberIsValid()
         {
             return SerialNumber >= 1 && SerialNumber <= 999;
+        }
+
+        public bool ChecksumIsValid()
+        {
+            var twoDigitYear = Year % 100;
+            var personalIdentityNumber = $"{twoDigitYear:D2}{Month:D2}{Day:D2}{SerialNumber:D3}";
+
+            var calculatedChecksum = LuhnChecksum.GetChecksum(personalIdentityNumber);
+
+            return Checksum == calculatedChecksum;
         }
     }
 }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Create.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Create.cs
@@ -55,6 +55,15 @@ namespace ActiveLogin.Identity.Swedish.Test
         }
 
         [Theory]
+        [InlineData(2018, 01, 01, 239, 3)]
+        [InlineData(2018, 01, 01, 239, 4)]
+        public void Throws_When_Invalid_Checksum(int year, int month, int day, int serialNumber, int checksum)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
+            Assert.Equal("Invalid checksum.\r\nParameter name: checksum", ex.Message);
+        }
+
+        [Theory]
         [InlineData(1899, 09, 13, 980, 1)]
         [InlineData(1999, 08, 07, 239, 1)]
         [InlineData(2000, 01, 02, 239, 1)]


### PR DESCRIPTION
Validates the last digit of the personal identity number using the lugn algorithm as described in https://en.wikipedia.org/wiki/Luhn_algorithm and https://sv.wikipedia.org/wiki/Personnummer_i_Sverige.