### PR TITLE
Change the way we asserts exceptions to work cross platform

### DIFF
--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Create.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Create.cs
@@ -15,7 +15,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_Year(int year, int month, int day, int serialNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
-            Assert.Equal($"Invalid year.\r\nParameter name: year\r\nActual value was {year}.", ex.Message);
+            Assert.Contains("Invalid year.", ex.Message);
         }
 
         [Theory]
@@ -24,7 +24,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_Month(int year, int month, int day, int serialNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
-            Assert.Equal($"Invalid month. Must be in the range 1 to 12.\r\nParameter name: month\r\nActual value was {month}.", ex.Message);
+            Assert.Contains("Invalid month.", ex.Message);
         }
 
         [Theory]
@@ -34,7 +34,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_Day(int year, int month, int day, int serialNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
-            Assert.Equal($"Invalid day of month.\r\nParameter name: day\r\nActual value was {day}.", ex.Message);
+            Assert.Contains("Invalid day of month.", ex.Message);
         }
 
         [Theory]
@@ -42,7 +42,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Possible_CoOrdinationNumber(int year, int month, int day, int serialNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
-            Assert.Equal($"Invalid day of month. It might be a valid co-ordination number.\r\nParameter name: day\r\nActual value was {day}.", ex.Message);
+            Assert.Contains("Invalid day of month.", ex.Message);
         }
 
         [Theory]
@@ -51,7 +51,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_SerialNumber(int year, int month, int day, int serialNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
-            Assert.Equal($"Invalid serial number. Must be in the range 0 to 999.\r\nParameter name: serialNumber\r\nActual value was {serialNumber}.", ex.Message);
+            Assert.Contains("Invalid serial number.", ex.Message);
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_Checksum(int year, int month, int day, int serialNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum));
-            Assert.Equal("Invalid checksum.\r\nParameter name: checksum", ex.Message);
+            Assert.Contains("Invalid checksum.", ex.Message);
         }
 
         [Theory]

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_GetAge.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_GetAge.cs
@@ -37,7 +37,7 @@ namespace ActiveLogin.Identity.Swedish.Test
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
             var ex = Assert.Throws<Exception>(() => personalIdentityNumber.GetAge(_date_2000_04_14));
 
-            Assert.Equal("The person is not yet born.", ex.Message);
+            Assert.Contains("The person is not yet born.", ex.Message);
         }
     }
 }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -9,7 +9,7 @@ namespace ActiveLogin.Identity.Swedish.Test
     /// </remarks>
     public class SwedishPersonalIdentityNumber_Parse
     {
-        private const string InvalidSwedishPersonalIdentityNumberErrorMessage = "Invalid Swedish personal identity number.\r\nParameter name: personalIdentityNumber";
+        private const string InvalidSwedishPersonalIdentityNumberErrorMessage = "Invalid Swedish personal identity number.";
         private readonly DateTime _date_2018_07_15 = new DateTime(2018, 07, 15);
 
         [Theory]
@@ -103,7 +103,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_Delimiter_From_Short_String(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
-            Assert.Equal(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
+            Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
 
@@ -196,7 +196,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Plus_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
-            Assert.Equal(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
+            Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
         [Theory]
@@ -207,7 +207,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Throws_When_Invalid_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
-            Assert.Equal(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
+            Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
     }
 }


### PR DESCRIPTION
As described in #17 tests were failing on Mac OS and also Linux due to assertions depending on the windows new line.

I've now configured Azure DevOps to build and run all tests on both Windows, Linux and Mac OS. The build will only succeed if all three passes.

The change to fix the tests are the one proposed in #17. Checking if the returned exception contains the relevant text, like "Invalid year.".