### PR TITLE
Seperate facts from hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SwedishPersonalIdentityNumber
 
 #### Hints
 
-Some data, such as DateOfBirth, Age and Gen der can't be garanteed to reflect the truth due to lmitied amount of personal identity numbers per day.
+Some data, such as DateOfBirth, Age and Gender can't be garanteed to reflect the truth due to lmitied amount of personal identity numbers per day.
 Therefore they are exposed as extension methods and are suffixed eith `Hint`no reflect this.
 
 #### ASP.NET Core MVC

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ if (SwedishPersonalIdentityNumber.TryParse(rawPersonalIdentityNumber, out var pe
     Console.WriteLine(" .ToShortString(): {0}", personalIdentityNumber.ToShortString());
     Console.WriteLine(" .ToLongString(): {0}", personalIdentityNumber.ToLongString());
 
-    Console.WriteLine(" .GetDateOfBirthHint(): {0}", personalIdentityNumber.DateOfBirth.ToShortDateString());
-    Console.WriteLine(" .GetAgeHint(): {0}", personalIdentityNumber.GetAge().ToString());
+    Console.WriteLine(" .GetDateOfBirthHint(): {0}", personalIdentityNumber.GetDateOfBirthHint().ToShortDateString());
+    Console.WriteLine(" .GetAgeHint(): {0}", personalIdentityNumber.GetAgeHint().ToString());
 
-    Console.WriteLine(" .GetGenderHint(): {0}", personalIdentityNumber.Gender.ToString());
+    Console.WriteLine(" .GetGenderHint(): {0}", personalIdentityNumber.GetGenderHint().ToString());
 }
 else
 {

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ if (SwedishPersonalIdentityNumber.TryParse(rawPersonalIdentityNumber, out var pe
     Console.WriteLine(" .ToShortString(): {0}", personalIdentityNumber.ToShortString());
     Console.WriteLine(" .ToLongString(): {0}", personalIdentityNumber.ToLongString());
 
-    Console.WriteLine(" .DateOfBirth: {0}", personalIdentityNumber.DateOfBirth.ToShortDateString());
-    Console.WriteLine(" .GetAge(): {0}", personalIdentityNumber.GetAge().ToString());
+    Console.WriteLine(" .GetDateOfBirthHint(): {0}", personalIdentityNumber.DateOfBirth.ToShortDateString());
+    Console.WriteLine(" .GetAgeHint(): {0}", personalIdentityNumber.GetAge().ToString());
 
-    Console.WriteLine(" .Gender: {0}", personalIdentityNumber.Gender.ToString());
+    Console.WriteLine(" .GetGenderHint(): {0}", personalIdentityNumber.Gender.ToString());
 }
 else
 {
@@ -59,10 +59,17 @@ SwedishPersonalIdentityNumber
  .ToString(): 990807-2391
  .ToShortString(): 990807-2391
  .ToLongString(): 199908072391
- .DateOfBirth: 1999-08-07
- .GetAge(): 18
- .Gender: Male
+ .GetDateOfBirthHint(): 1999-08-07
+ .GetAgeHint(): 18
+ .GetGenderHint(): Male
 ```
+
+#### Hints
+
+Some data, such as DateOfBirth, Age and Gen der can't be garanteed to reflect the truth due to lmitied amount of personal identity numbers per day.
+Therefore they are exposed as extension methods and are suffixed eith `Hint`no reflect this.
+
+#### ASP.NET Core MVC
 
 If used to validate input in an ASP.NET Core MVC project, the `SwedishPersonalIdentityNumberAttribute` can be used  like this:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SwedishPersonalIdentityNumber
 
 #### Hints
 
-Some data, such as DateOfBirth, Age and Gender can't be garanteed to reflect the truth due to lmitied amount of personal identity numbers per day.
+Some data, such as DateOfBirth, Age and Gender can't be garanteed to reflect the truth due to limitied amount of personal identity numbers per day.
 Therefore they are exposed as extension methods and are suffixed with `Hint` to reflect this.
 
 #### ASP.NET Core MVC

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ SwedishPersonalIdentityNumber
 #### Hints
 
 Some data, such as DateOfBirth, Age and Gender can't be garanteed to reflect the truth due to lmitied amount of personal identity numbers per day.
-Therefore they are exposed as extension methods and are suffixed eith `Hint`no reflect this.
+Therefore they are exposed as extension methods and are suffixed with `Hint` to reflect this.
 
 #### ASP.NET Core MVC
 

--- a/samples/ConsoleSample/Program.cs
+++ b/samples/ConsoleSample/Program.cs
@@ -62,10 +62,10 @@ namespace ConsoleSample
             WriteKeyValueInfo("   .SerialNumber", personalIdentityNumber.SerialNumber.ToString());
             WriteKeyValueInfo("   .Checksum", personalIdentityNumber.Checksum.ToString());
 
-            WriteKeyValueInfo("   .DateOfBirth", personalIdentityNumber.DateOfBirth.ToShortDateString());
-            WriteKeyValueInfo("   .GetAge()", personalIdentityNumber.GetAge().ToString());
+            WriteKeyValueInfo("   .GetDateOfBirthHint()", personalIdentityNumber.GetDateOfBirthHint().ToShortDateString());
+            WriteKeyValueInfo("   .GetAgeHint()", personalIdentityNumber.GetAgeHint().ToString());
 
-            WriteKeyValueInfo("   .Gender", personalIdentityNumber.Gender.ToString());
+            WriteKeyValueInfo("   .GetGenderHint()", personalIdentityNumber.GetGenderHint().ToString());
         }
 
         private static void WriteHeader(string header)

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -40,13 +40,6 @@ namespace ActiveLogin.Identity.Swedish
         /// </summary>
         public DateTime DateOfBirth { get; }
 
-        /// <summary>
-        /// Gender (juridiskt kön) in Sweden according to the last digit of the serial number in the personal identity number.
-        /// Odd number: Male
-        /// Even number: Female
-        /// </summary>
-        public Gender Gender { get; }
-
         private SwedishPersonalIdentityNumber(int year, int month, int day, int serialNumber, int checksum)
         {
             Year = year;
@@ -57,7 +50,6 @@ namespace ActiveLogin.Identity.Swedish
             Checksum = checksum;
 
             DateOfBirth = GetDateOfBirth(Year, Month, Day);
-            Gender = GetGender(SerialNumber);
         }
 
         /// <summary>
@@ -251,17 +243,6 @@ namespace ActiveLogin.Identity.Swedish
         private static DateTime GetDateOfBirth(int year, int month, int day)
         {
             return new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
-        }
-
-        private static Gender GetGender(int serialNumber)
-        {
-            var isSerialNumberEven = serialNumber % 2 == 0;
-            if (isSerialNumberEven)
-            {
-                return Gender.Female;
-            }
-
-            return Gender.Male;
         }
 
         /// <summary>Returns a value indicating whether this instance is equal to a specified object.</summary>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -35,11 +35,6 @@ namespace ActiveLogin.Identity.Swedish
         /// </summary>
         public int Checksum { get; }
 
-        /// <summary>
-        /// Date of birth for the person according to the personal identity number.
-        /// </summary>
-        public DateTime DateOfBirth { get; }
-
         private SwedishPersonalIdentityNumber(int year, int month, int day, int serialNumber, int checksum)
         {
             Year = year;
@@ -48,8 +43,6 @@ namespace ActiveLogin.Identity.Swedish
 
             SerialNumber = serialNumber;
             Checksum = checksum;
-
-            DateOfBirth = GetDateOfBirth(Year, Month, Day);
         }
 
         /// <summary>
@@ -184,7 +177,8 @@ namespace ActiveLogin.Identity.Swedish
         /// <param name="date">The date to decide wheter the person is older than 100 years. That decides the delimiter (- or +).</param>
         public string ToShortString(DateTime date)
         {
-            var age = GetAge(date);
+            var dateOfBirth = SwedishPersonalIdentityNumberDateCalculations.GetDateOfBirth(Year, Month, Day);
+            var age = SwedishPersonalIdentityNumberDateCalculations.GetAge(dateOfBirth, date);
             var delimiter = age >= 100 ? '+' : '-';
             var twoDigitYear = Year % 100;
             return $"{twoDigitYear:D2}{Month:D2}{Day:D2}{delimiter}{SerialNumber:D3}{Checksum}";
@@ -206,43 +200,6 @@ namespace ActiveLogin.Identity.Swedish
         public override string ToString()
         {
             return ToShortString();
-        }
-
-        /// <summary>
-        /// Get the age of the person.
-        /// </summary>
-        public int GetAge()
-        {
-            return GetAge(DateTime.UtcNow);
-        }
-
-        /// <summary>
-        /// Get the age of the person.
-        /// </summary>
-        /// <param name="date">The date when to calulate the age.</param>
-        /// <returns></returns>
-        public int GetAge(DateTime date)
-        {
-            var dateOfBirth = DateOfBirth;
-            var age = date.Year - dateOfBirth.Year;
-
-            if (date.Month < dateOfBirth.Month ||
-               (date.Month == dateOfBirth.Month && date.Day < dateOfBirth.Day))
-            {
-                age -= 1;
-            }
-
-            if (age < 0)
-            {
-                throw new Exception("The person is not yet born.");
-            }
-
-            return age;
-        }
-
-        private static DateTime GetDateOfBirth(int year, int month, int day)
-        {
-            return new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
         }
 
         /// <summary>Returns a value indicating whether this instance is equal to a specified object.</summary>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberDateCalculations.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberDateCalculations.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace ActiveLogin.Identity.Swedish
+{
+    internal static class SwedishPersonalIdentityNumberDateCalculations
+    {
+        public static DateTime GetDateOfBirth(int year, int month, int day)
+        {
+            return new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+        }
+
+        public static int GetAge(DateTime dateOfBirth, DateTime date)
+        {
+            var age = date.Year - dateOfBirth.Year;
+
+            if (date.Month < dateOfBirth.Month ||
+                (date.Month == dateOfBirth.Month && date.Day < dateOfBirth.Day))
+            {
+                age -= 1;
+            }
+
+            if (age < 0)
+            {
+                throw new Exception("The person is not yet born.");
+            }
+
+            return age;
+        }
+    }
+}

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberHintExtensions.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberHintExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace ActiveLogin.Identity.Swedish
+{
+    public static class SwedishPersonalIdentityNumberHintExtensions
+    {
+        /// <summary>
+        /// Gender (juridiskt kön) in Sweden according to the last digit of the serial number in the personal identity number.
+        /// Odd number: Male
+        /// Even number: Female
+        /// </summary>
+        public static Gender GetGenderHint(this SwedishPersonalIdentityNumber personalIdentityNumber)
+        {
+            return GetGender(personalIdentityNumber.SerialNumber);
+        }
+
+        private static Gender GetGender(int serialNumber)
+        {
+            var isSerialNumberEven = serialNumber % 2 == 0;
+            if (isSerialNumberEven)
+            {
+                return Gender.Female;
+            }
+
+            return Gender.Male;
+        }
+    }
+}

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberHintExtensions.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberHintExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace ActiveLogin.Identity.Swedish
+﻿using System;
+
+namespace ActiveLogin.Identity.Swedish
 {
     public static class SwedishPersonalIdentityNumberHintExtensions
     {
@@ -21,6 +23,36 @@
             }
 
             return Gender.Male;
+        }
+
+        /// <summary>
+        /// Date of birth for the person according to the personal identity number.
+        /// Not always the actual date of birth due to lmitied amount of personal identity numbers per day.
+        /// </summary>
+        public static DateTime GetDateOfBirthHint(this SwedishPersonalIdentityNumber personalIdentityNumber)
+        {
+            return SwedishPersonalIdentityNumberDateCalculations.GetDateOfBirth(personalIdentityNumber.Year, personalIdentityNumber.Month, personalIdentityNumber.Day);
+        }
+
+        /// <summary>
+        /// Get the age of the person according to the date in the personal identity number.
+        /// Not always the actual date of birth due to lmitied amount of personal identity numbers per day.
+        /// </summary>
+        public static int GetAgeHint(this SwedishPersonalIdentityNumber personalIdentityNumber)
+        {
+            return GetAgeHint(personalIdentityNumber, DateTime.UtcNow);
+        }
+
+        /// <summary>
+        /// Get the age of the person according to the date in the personal identity number.
+        /// Not always the actual date of birth due to lmitied amount of personal identity numbers per day.
+        /// </summary>
+        /// <param name="personalIdentityNumber"></param>
+        /// <param name="date">The date when to calulate the age.</param>
+        /// <returns></returns>
+        public static int GetAgeHint(this SwedishPersonalIdentityNumber personalIdentityNumber, DateTime date)
+        {
+            return SwedishPersonalIdentityNumberDateCalculations.GetAge(personalIdentityNumber.GetDateOfBirthHint(), date);
         }
     }
 }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetAgeHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetAgeHint.cs
@@ -7,7 +7,7 @@ namespace ActiveLogin.Identity.Swedish.Test
     /// Tested with offical test Personal Identity Numbers from Skatteverket:
     /// https://skatteverket.entryscape.net/catalog/9/datasets/147
     /// </remarks>
-    public class SwedishPersonalIdentityNumber_GetAge
+    public class SwedishPersonalIdentityNumberHintExtensions_GetAgeHint
     {
         private readonly DateTime _date_2018_07_15 = new DateTime(2018, 07, 15);
         private readonly DateTime _date_2000_04_14 = new DateTime(2000, 04, 14);
@@ -18,7 +18,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Older_Than_100_Years_Caluclates_Age(int year, int month, int day, int serialNumber, int checksum, int expectedAge)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            Assert.Equal(expectedAge, personalIdentityNumber.GetAge(_date_2018_07_15));
+            Assert.Equal(expectedAge, personalIdentityNumber.GetAgeHint(_date_2018_07_15));
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Younger_Than_100_Years_Caluclates_Age(int year, int month, int day, int serialNumber, int checksum, int expectedAge)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            Assert.Equal(expectedAge, personalIdentityNumber.GetAge(_date_2018_07_15));
+            Assert.Equal(expectedAge, personalIdentityNumber.GetAgeHint(_date_2018_07_15));
         }
 
         [Theory]
@@ -35,7 +35,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Not_Yet_Born_Throws_Exception(int year, int month, int day, int serialNumber, int checksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            var ex = Assert.Throws<Exception>(() => personalIdentityNumber.GetAge(_date_2000_04_14));
+            var ex = Assert.Throws<Exception>(() => personalIdentityNumber.GetAgeHint(_date_2000_04_14));
 
             Assert.Contains("The person is not yet born.", ex.Message);
         }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetDateOfBirthHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetDateOfBirthHint.cs
@@ -7,7 +7,7 @@ namespace ActiveLogin.Identity.Swedish.Test
     /// Tested with offical test Personal Identity Numbers from Skatteverket:
     /// https://skatteverket.entryscape.net/catalog/9/datasets/147
     /// </remarks>
-    public class SwedishPersonalIdentityNumber_DateOfBirth
+    public class SwedishPersonalIdentityNumberHintExtensions_GetDateOfBirthHint
     {
         [Theory]
         [InlineData(1899, 09, 13, 980, 1)]
@@ -15,7 +15,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Year_Equals_Year(int year, int month, int day, int serialNumber, int checksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            var dateOfBirth = personalIdentityNumber.DateOfBirth;
+            var dateOfBirth = personalIdentityNumber.GetDateOfBirthHint();
             Assert.Equal(year, dateOfBirth.Year);
         }
 
@@ -25,7 +25,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Month_Equals_Month(int year, int month, int day, int serialNumber, int checksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            var dateOfBirth = personalIdentityNumber.DateOfBirth;
+            var dateOfBirth = personalIdentityNumber.GetDateOfBirthHint();
             Assert.Equal(month, dateOfBirth.Month);
         }
 
@@ -35,7 +35,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void Day_Equals_Day(int year, int month, int day, int serialNumber, int checksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            var dateOfBirth = personalIdentityNumber.DateOfBirth;
+            var dateOfBirth = personalIdentityNumber.GetDateOfBirthHint();
             Assert.Equal(day, dateOfBirth.Day);
         }
     }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetGenderHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetGenderHint.cs
@@ -6,7 +6,7 @@ namespace ActiveLogin.Identity.Swedish.Test
     /// Tested with offical test Personal Identity Numbers from Skatteverket:
     /// https://skatteverket.entryscape.net/catalog/9/datasets/147
     /// </remarks>
-    public class SwedishPersonalIdentityNumber_Gender
+    public class SwedishPersonalIdentityNumberHintExtensions_GetGenderHint
     {
         [Theory]
         [InlineData(1899, 09, 13, 980, 1)]

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Gender.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Gender.cs
@@ -15,7 +15,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Last_Digit_In_SerialNumber_Is_Even_It_Is_A_Woman(int year, int month, int day, int serialNumber, int checksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            Assert.Equal(Gender.Female, personalIdentityNumber.Gender);
+            Assert.Equal(Gender.Female, personalIdentityNumber.GetGenderHint());
         }
 
         [Theory]
@@ -24,7 +24,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Last_Digit_In_SerialNumber_Is_Odd_It_Is_A_Man(int year, int month, int day, int serialNumber, int checksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            Assert.Equal(Gender.Male, personalIdentityNumber.Gender);
+            Assert.Equal(Gender.Male, personalIdentityNumber.GetGenderHint());
         }
     }
 }


### PR DESCRIPTION
This implements #19.

Some data, such as DateOfBirth, Age and Gender can't be garanteed to reflect the truth due to limitied amount of personal identity numbers per day.
Therefore they are exposed as extension methods and are suffixed with `Hint` to reflect this.

New syntax:

```csharp
Console.WriteLine("SwedishPersonalIdentityNumber");
Console.WriteLine(" .ToString(): {0}", personalIdentityNumber.ToString());
Console.WriteLine(" .ToShortString(): {0}", personalIdentityNumber.ToShortString());
Console.WriteLine(" .ToLongString(): {0}", personalIdentityNumber.ToLongString());

Console.WriteLine(" .GetDateOfBirthHint(): {0}", personalIdentityNumber.GetDateOfBirthHint().ToShortDateString());
Console.WriteLine(" .GetAgeHint(): {0}", personalIdentityNumber.GetAgeHint().ToString());

Console.WriteLine(" .GetGenderHint(): {0}", personalIdentityNumber.GetGenderHint().ToString());
````