### PR TITLE
Fix 100 year bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ For more usecases, samples and inspiration; feel free to browse our unit tests a
 
 The implementation is based on the definitions as described here:
 
+* [Folkbokföringslagen (FOL 18 §)](https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18)
 * [Skatteverket (English)](https://www.skatteverket.se/servicelankar/otherlanguages/inenglish/individualsandemployees/livinginsweden/personalidentitynumberandcoordinationnumber.4.2cf1b5cd163796a5c8b4295.html)
 * [Skatteverket (Swedish)](https://www.skatteverket.se/privat/folkbokforing/personnummerochsamordningsnummer.4.3810a01c150939e893f18c29.html)
-* [Wikipedia (English)](https://en.wikipedia.org/wiki/Personal_identity_number_(Sweden))
-* [Wikipedia (Swedish)](https://sv.wikipedia.org/wiki/Personnummer_i_Sverige)
+
+Worth noticing is that the date part is not guaranteed to be the exact date you were born, but can be changed for another date within the same month.
 
 ### Why are you calling it "Swedish Personal Identity Number" and not Social Security Number?
 
@@ -112,7 +113,7 @@ To comply with GDPR and not no expose any real PINs, we are using the official t
 
 ### Why is there an overload to pass a date to Parse and ToString()?
 
-Some forms of a Swedish Personal Identity Number depends of the age of the person it represents. The "-" will be replaced with a "+" once the person is 100 years old or older. Therefore an overload exists to define at what point in the the data should be represented. Useful for parsing old data or printing data fore the future.
+Some forms of a Swedish Personal Identity Number depends of the age of the person it represents. The "-" will be replaced with a "+" the year a person is 100 years old or older. Therefore an overload exists to define at what point in the the data should be represented. Useful for parsing old data or printing data fore the future.
 
 ## ActiveLogin
 

--- a/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.csproj
+++ b/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.csproj
@@ -12,7 +12,7 @@
     <PackageId>ActiveLogin.Identity.Swedish</PackageId>
 
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>alpha-2</VersionSuffix>
+    <VersionSuffix>alpha-3</VersionSuffix>
     <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
     <Description>.NET classes that enables parsing and validation of Swedish identities such as Personal Identity Number (svenskt personnummer) in .NET.</Description>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -108,7 +108,7 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="date">The date to decide whether the person is older than 100 years. That decides the delimiter (- or +).</param>
+        /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
         public static SwedishPersonalIdentityNumber Parse(string personalIdentityNumber, DateTime date)
         {
             try
@@ -145,7 +145,7 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent  and returns a value that indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="date">The date to decide whether the person is older than 100 years. That decides the delimiter (- or +).</param>
+        /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
         /// <param name="result">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
         public static bool TryParse(string personalIdentityNumber, DateTime date, out SwedishPersonalIdentityNumber result)
         {
@@ -174,14 +174,20 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent short string representation.
         /// Format is YYMMDDXSSSC, for example <example>990807-2391</example> or <example>120211+9986</example>.
         /// </summary>
-        /// <param name="date">The date to decide whether the person is older than 100 years. That decides the delimiter (- or +).</param>
+        /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
         public string ToShortString(DateTime date)
         {
             var dateOfBirth = SwedishPersonalIdentityNumberDateCalculations.GetDateOfBirth(Year, Month, Day);
-            var age = SwedishPersonalIdentityNumberDateCalculations.GetAge(dateOfBirth, date);
+            var firstDayOfYearInDateOfBirth = GetFirstDayOfYear(dateOfBirth);
+            var age = SwedishPersonalIdentityNumberDateCalculations.GetAge(firstDayOfYearInDateOfBirth, date);
             var delimiter = age >= 100 ? '+' : '-';
             var twoDigitYear = Year % 100;
             return $"{twoDigitYear:D2}{Month:D2}{Day:D2}{delimiter}{SerialNumber:D3}{Checksum}";
+        }
+
+        private DateTime GetFirstDayOfYear(DateTime date)
+        {
+            return new DateTime(date.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         }
 
         /// <summary>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -177,17 +177,10 @@ namespace ActiveLogin.Identity.Swedish
         /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
         public string ToShortString(DateTime date)
         {
-            var dateOfBirth = SwedishPersonalIdentityNumberDateCalculations.GetDateOfBirth(Year, Month, Day);
-            var firstDayOfYearInDateOfBirth = GetFirstDayOfYear(dateOfBirth);
-            var age = SwedishPersonalIdentityNumberDateCalculations.GetAge(firstDayOfYearInDateOfBirth, date);
-            var delimiter = age >= 100 ? '+' : '-';
+            var years = date.Year - Year;
+            var delimiter = years >= 100 ? '+' : '-';
             var twoDigitYear = Year % 100;
             return $"{twoDigitYear:D2}{Month:D2}{Day:D2}{delimiter}{SerialNumber:D3}{Checksum}";
-        }
-
-        private DateTime GetFirstDayOfYear(DateTime date)
-        {
-            return new DateTime(date.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         }
 
         /// <summary>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
@@ -103,8 +103,7 @@ namespace ActiveLogin.Identity.Swedish
             var fullYear = currentCentury + shortYear;
 
             var dateOfBirth = new DateTime(fullYear, month, day, 0, 0, 0, DateTimeKind.Utc);
-            var firstDayOfYearInDateOfBirth = new DateTime(dateOfBirth.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            if (firstDayOfYearInDateOfBirth > date)
+            if (dateOfBirth.Year > date.Year)
             {
                 dateOfBirth = dateOfBirth.AddYears(-100);
             }

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
@@ -103,7 +103,8 @@ namespace ActiveLogin.Identity.Swedish
             var fullYear = currentCentury + shortYear;
 
             var dateOfBirth = new DateTime(fullYear, month, day, 0, 0, 0, DateTimeKind.Utc);
-            if (dateOfBirth > date)
+            var firstDayOfYearInDateOfBirth = new DateTime(dateOfBirth.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            if (firstDayOfYearInDateOfBirth > date)
             {
                 dateOfBirth = dateOfBirth.AddYears(-100);
             }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -11,13 +11,23 @@ namespace ActiveLogin.Identity.Swedish.Test
     {
         private const string InvalidSwedishPersonalIdentityNumberErrorMessage = "Invalid Swedish personal identity number.";
         private readonly DateTime _date_2018_07_15 = new DateTime(2018, 07, 15);
+        private readonly DateTime _date_2012_01_01 = new DateTime(2012, 01, 01);
 
         [Theory]
+        [InlineData("900101+9802", 1890)]
         [InlineData("990913+9801", 1899)]
         [InlineData("120211+9986", 1912)]
         public void Parses_Year_From_Short_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2012_01_01);
+            Assert.Equal(expectedYear, personalIdentityNumber.Year);
+        }
+
+        [Theory]
+        [InlineData("900101+9802", 1890)]
+        public void Parses_Year_From_Short_String_When_Year_Is_Exact_100_Years(string personalIdentityNumberString, int expectedYear)
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, new DateTime(1990, 01, 01));
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_ToShortString.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_ToShortString.cs
@@ -10,14 +10,24 @@ namespace ActiveLogin.Identity.Swedish.Test
     public class SwedishPersonalIdentityNumber_ToShortString
     {
         private readonly DateTime _date_2018_07_15 = new DateTime(2018, 07, 15);
+        private readonly DateTime _date_2012_01_01 = new DateTime(2012, 01, 01);
 
         [Theory]
+        [InlineData(1890, 01, 01, 980, 2, "900101+9802")]
         [InlineData(1899, 09, 13, 980, 1, "990913+9801")]
         [InlineData(1912, 02, 11, 998, 6, "120211+9986")]
-        public void When_Older_Than_100_Years_Uses_Plus_As_Delimiter(int year, int month, int day, int serialNumber, int checksum, string expected)
+        public void The_Year_You_Turn_100_Years_Uses_Plus_As_Delimiter(int year, int month, int day, int serialNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.ToShortString(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.ToShortString(_date_2012_01_01));
+        }
+
+        [Theory]
+        [InlineData(1890, 01, 01, 980, 2, "900101+9802")]
+        public void The_Year_You_Turn_100_Years_Uses_Plus_As_Delimiter_Also_Exact_100_Years(int year, int month, int day, int serialNumber, int checksum, string expected)
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, serialNumber, checksum);
+            Assert.Equal(expected, personalIdentityNumber.ToShortString(new DateTime(1990, 01, 01)));
         }
 
         [Theory]


### PR DESCRIPTION
Previously we chanhed the delmiter from - to + when the person turned 100 years old. This was wrong. We now change the year when the person turns 100 years old.

Fixes #31.