### PR TITLE
Move Parse() and ToString() overloads to separate methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ Unforentunately the term "social security number" or SSN is often used even for 
 
 To comply with GDPR and not no expose any real PINs, we are using the official test data for Swedish Personal Identity Numbers [provided by Skatteverket](https://skatteverket.entryscape.net/catalog/9/datasets/147).
 
-### Why is there an overload to pass a date to Parse and ToString()?
+### When should I use `.To10DigitStringInSpecificYear(...)`, `.ParseInSpecificYear(...)` or `.TryParseInSpecificYear(...)`?
 
-Some forms of a Swedish Personal Identity Number depends of the age of the person it represents. The "-" will be replaced with a "+" the year a person is 100 years old or older. Therefore an overload exists to define at what point in the the data should be represented. Useful for parsing old data or printing data fore the future.
+Some forms of a Swedish Personal Identity Number depends of the age of the person it represents.
+The "-" will be replaced with a "+" the year a person is 100 years old or older. Therefore these methods exists to define at what year the the data should be represented or parsed.
+Useful for parsing old data or printing data fore the future.
 
 ## Active Login
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ To comply with GDPR and not no expose any real PINs, we are using the official t
 ### When should I use `.To10DigitStringInSpecificYear(...)`, `.ParseInSpecificYear(...)` or `.TryParseInSpecificYear(...)`?
 
 Some forms of a Swedish Personal Identity Number depends of the age of the person it represents.
-The "-" will be replaced with a "+" the year a person is 100 years old or older. Therefore these methods exists to define at what year the the data should be represented or parsed.
-Useful for parsing old data or printing data fore the future.
+The "-" will be replaced with a "+" on January 1st the year a person turns 100 years old. Therefore these methods exists to define at what year the the data should be represented or parsed.
+Useful for parsing old data or printing data for the future.
 
 ## Active Login
 

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -101,24 +101,24 @@ namespace ActiveLogin.Identity.Swedish
         /// </summary>
         public static SwedishPersonalIdentityNumber Parse(string personalIdentityNumber)
         {
-            return ParseInSpecificYear(personalIdentityNumber, DateTime.UtcNow);
+            return ParseInSpecificYear(personalIdentityNumber, DateTime.UtcNow.Year);
         }
 
         /// <summary>
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="currentYear">
+        /// <param name="parseYear">
         /// The specific year to use when checking if the person has turned / will turn 100 years old.
         /// That information changes the delimiter (- or +).
         ///
         /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
         /// </param>
-        public static SwedishPersonalIdentityNumber ParseInSpecificYear(string personalIdentityNumber, DateTime currentYear)
+        public static SwedishPersonalIdentityNumber ParseInSpecificYear(string personalIdentityNumber, int parseYear)
         {
             try
             {
-                var parsed = SwedishPersonalIdentityNumberParser.Parse(personalIdentityNumber, currentYear);
+                var parsed = SwedishPersonalIdentityNumberParser.Parse(personalIdentityNumber, parseYear);
                 return new SwedishPersonalIdentityNumber(parsed.Year, parsed.Month, parsed.Day, parsed.BirthNumber, parsed.Checksum);
             }
             catch (ArgumentException)
@@ -150,18 +150,18 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent  and returns a value that indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="currentYear">
+        /// <param name="parseYear">
         /// The specific year to use when checking if the person has turned / will turn 100 years old.
         /// That information changes the delimiter (- or +).
         ///
         /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
         /// </param>
         /// <param name="result">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
-        public static bool TryParse(string personalIdentityNumber, DateTime currentYear, out SwedishPersonalIdentityNumber result)
+        public static bool TryParse(string personalIdentityNumber, int parseYear, out SwedishPersonalIdentityNumber result)
         {
             try
             {
-                result = ParseInSpecificYear(personalIdentityNumber, currentYear);
+                result = ParseInSpecificYear(personalIdentityNumber, parseYear);
                 return true;
             }
             catch (Exception)
@@ -177,22 +177,22 @@ namespace ActiveLogin.Identity.Swedish
         /// </summary>
         public string To10DigitString()
         {
-            return To10DigitStringInSpecificYear(DateTime.UtcNow);
+            return To10DigitStringInSpecificYear(DateTime.UtcNow.Year);
         }
 
         /// <summary>
         /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent 10 digit string representation. The total length, including the separator, will be 11 chars.
         /// Format is YYMMDDXSSSC, for example <example>990807-2391</example> or <example>120211+9986</example>.
         /// </summary>
-        /// <param name="currentYear">
+        /// <param name="serializationYear">
         /// The specific year to use when checking if the person has turned / will turn 100 years old.
         /// That information changes the delimiter (- or +).
         ///
         /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
         /// </param>
-        public string To10DigitStringInSpecificYear(DateTime currentYear)
+        public string To10DigitStringInSpecificYear(int serializationYear)
         {
-            var years = currentYear.Year - Year;
+            var years = serializationYear - Year;
             var delimiter = years >= 100 ? '+' : '-';
             var twoDigitYear = Year % 100;
             return $"{twoDigitYear:D2}{Month:D2}{Day:D2}{delimiter}{BirthNumber:D3}{Checksum}";

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -108,12 +108,12 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
-        public static SwedishPersonalIdentityNumber Parse(string personalIdentityNumber, DateTime date)
+        /// <param name="currentYear">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
+        public static SwedishPersonalIdentityNumber Parse(string personalIdentityNumber, DateTime currentYear)
         {
             try
             {
-                var parsed = SwedishPersonalIdentityNumberParser.Parse(personalIdentityNumber, date);
+                var parsed = SwedishPersonalIdentityNumberParser.Parse(personalIdentityNumber, currentYear);
                 return new SwedishPersonalIdentityNumber(parsed.Year, parsed.Month, parsed.Day, parsed.BirthNumber, parsed.Checksum);
             }
             catch (ArgumentException)
@@ -145,13 +145,13 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent  and returns a value that indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
+        /// <param name="currentYear">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
         /// <param name="result">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
-        public static bool TryParse(string personalIdentityNumber, DateTime date, out SwedishPersonalIdentityNumber result)
+        public static bool TryParse(string personalIdentityNumber, DateTime currentYear, out SwedishPersonalIdentityNumber result)
         {
             try
             {
-                result = Parse(personalIdentityNumber, date);
+                result = Parse(personalIdentityNumber, currentYear);
                 return true;
             }
             catch (Exception)
@@ -174,11 +174,11 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent 10 digit string representation. The total length, including the separator, will be 11 chars.
         /// Format is YYMMDDXSSSC, for example <example>990807-2391</example> or <example>120211+9986</example>.
         /// </summary>
-        /// <param name="date">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
+        /// <param name="currentYear">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
 
-        public string To10DigitString(DateTime date)
+        public string To10DigitString(DateTime currentYear)
         {
-            var years = date.Year - Year;
+            var years = currentYear.Year - Year;
             var delimiter = years >= 100 ? '+' : '-';
             var twoDigitYear = Year % 100;
             return $"{twoDigitYear:D2}{Month:D2}{Day:D2}{delimiter}{BirthNumber:D3}{Checksum}";

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -157,7 +157,7 @@ namespace ActiveLogin.Identity.Swedish
         /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
         /// </param>
         /// <param name="result">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
-        public static bool TryParse(string personalIdentityNumber, int parseYear, out SwedishPersonalIdentityNumber result)
+        public static bool TryParseInSpecificYear(string personalIdentityNumber, int parseYear, out SwedishPersonalIdentityNumber result)
         {
             try
             {

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.cs
@@ -101,15 +101,20 @@ namespace ActiveLogin.Identity.Swedish
         /// </summary>
         public static SwedishPersonalIdentityNumber Parse(string personalIdentityNumber)
         {
-            return Parse(personalIdentityNumber, DateTime.UtcNow);
+            return ParseInSpecificYear(personalIdentityNumber, DateTime.UtcNow);
         }
 
         /// <summary>
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="currentYear">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
-        public static SwedishPersonalIdentityNumber Parse(string personalIdentityNumber, DateTime currentYear)
+        /// <param name="currentYear">
+        /// The specific year to use when checking if the person has turned / will turn 100 years old.
+        /// That information changes the delimiter (- or +).
+        ///
+        /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
+        /// </param>
+        public static SwedishPersonalIdentityNumber ParseInSpecificYear(string personalIdentityNumber, DateTime currentYear)
         {
             try
             {
@@ -145,13 +150,18 @@ namespace ActiveLogin.Identity.Swedish
         /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent  and returns a value that indicates whether the conversion succeeded.
         /// </summary>
         /// <param name="personalIdentityNumber">A string representation of the personal identity number to parse.</param>
-        /// <param name="currentYear">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
+        /// <param name="currentYear">
+        /// The specific year to use when checking if the person has turned / will turn 100 years old.
+        /// That information changes the delimiter (- or +).
+        ///
+        /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
+        /// </param>
         /// <param name="result">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
         public static bool TryParse(string personalIdentityNumber, DateTime currentYear, out SwedishPersonalIdentityNumber result)
         {
             try
             {
-                result = Parse(personalIdentityNumber, currentYear);
+                result = ParseInSpecificYear(personalIdentityNumber, currentYear);
                 return true;
             }
             catch (Exception)
@@ -167,16 +177,20 @@ namespace ActiveLogin.Identity.Swedish
         /// </summary>
         public string To10DigitString()
         {
-            return To10DigitString(DateTime.UtcNow);
+            return To10DigitStringInSpecificYear(DateTime.UtcNow);
         }
 
         /// <summary>
         /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent 10 digit string representation. The total length, including the separator, will be 11 chars.
         /// Format is YYMMDDXSSSC, for example <example>990807-2391</example> or <example>120211+9986</example>.
         /// </summary>
-        /// <param name="currentYear">The date to decide whether the person is has turned / will turn 100 years old that year. That decides the delimiter (- or +).</param>
-
-        public string To10DigitString(DateTime currentYear)
+        /// <param name="currentYear">
+        /// The specific year to use when checking if the person has turned / will turn 100 years old.
+        /// That information changes the delimiter (- or +).
+        ///
+        /// For more info, see: https://www.riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/folkbokforingslag-1991481_sfs-1991-481#P18
+        /// </param>
+        public string To10DigitStringInSpecificYear(DateTime currentYear)
         {
             var years = currentYear.Year - Year;
             var delimiter = years >= 100 ? '+' : '-';

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
@@ -5,11 +5,11 @@ namespace ActiveLogin.Identity.Swedish
 {
     internal static class SwedishPersonalIdentityNumberParser
     {
-        public static SwedishPersonalIdentityNumberParts Parse(string personalIdentityNumber, DateTime date)
+        public static SwedishPersonalIdentityNumberParts Parse(string personalIdentityNumber, DateTime currentYear)
         {
             var trimmedPersonalIdentityNumber = personalIdentityNumber.Trim();
 
-            if (TryParseShortPattern(trimmedPersonalIdentityNumber, date, out var parsedShort))
+            if (TryParseShortPattern(trimmedPersonalIdentityNumber, currentYear, out var parsedShort))
             {
                 return parsedShort;
             }
@@ -25,7 +25,7 @@ namespace ActiveLogin.Identity.Swedish
         /// <summary>
         /// YYYYMMDDSSSC, YYYYMMDD-SSSC or YYYYMMDD+SSSC
         /// </summary>
-        private static bool TryParseShortPattern(string personalIdentityNumber, DateTime date, out SwedishPersonalIdentityNumberParts parts)
+        private static bool TryParseShortPattern(string personalIdentityNumber, DateTime currentYear, out SwedishPersonalIdentityNumberParts parts)
         {
             var pattern = new Regex(@"^" +
                             @"(?<year>[0-9]{2})" +
@@ -45,7 +45,7 @@ namespace ActiveLogin.Identity.Swedish
 
             var partsFromMatch = GetPartsFromMatch(match);
             var delimiter = GetStringValue(match, "delimiter");
-            var fullYear = GetFullYear(partsFromMatch.Year, partsFromMatch.Month, partsFromMatch.Day, delimiter, date);
+            var fullYear = GetFullYear(partsFromMatch.Year, partsFromMatch.Month, partsFromMatch.Day, delimiter, currentYear);
         
             parts = new SwedishPersonalIdentityNumberParts(fullYear, partsFromMatch.Month, partsFromMatch.Day, partsFromMatch.BirthNumber, partsFromMatch.Checksum);
             return true;
@@ -97,13 +97,13 @@ namespace ActiveLogin.Identity.Swedish
             return longPatternMatch.Groups[groupName].Value;
         }
 
-        private static int GetFullYear(int shortYear, int month, int day, string delimiter, DateTime date)
+        private static int GetFullYear(int shortYear, int month, int day, string delimiter, DateTime currentYear)
         {
-            var currentCentury = (date.Year / 100) * 100;
+            var currentCentury = (currentYear.Year / 100) * 100;
             var fullYear = currentCentury + shortYear;
 
             var dateOfBirth = new DateTime(fullYear, month, day, 0, 0, 0, DateTimeKind.Utc);
-            if (dateOfBirth.Year > date.Year)
+            if (dateOfBirth.Year > currentYear.Year)
             {
                 dateOfBirth = dateOfBirth.AddYears(-100);
             }

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberParser.cs
@@ -5,11 +5,11 @@ namespace ActiveLogin.Identity.Swedish
 {
     internal static class SwedishPersonalIdentityNumberParser
     {
-        public static SwedishPersonalIdentityNumberParts Parse(string personalIdentityNumber, DateTime currentYear)
+        public static SwedishPersonalIdentityNumberParts Parse(string personalIdentityNumber, int parseYear)
         {
             var trimmedPersonalIdentityNumber = personalIdentityNumber.Trim();
 
-            if (TryParseShortPattern(trimmedPersonalIdentityNumber, currentYear, out var parsedShort))
+            if (TryParseShortPattern(trimmedPersonalIdentityNumber, parseYear, out var parsedShort))
             {
                 return parsedShort;
             }
@@ -25,7 +25,7 @@ namespace ActiveLogin.Identity.Swedish
         /// <summary>
         /// YYYYMMDDSSSC, YYYYMMDD-SSSC or YYYYMMDD+SSSC
         /// </summary>
-        private static bool TryParseShortPattern(string personalIdentityNumber, DateTime currentYear, out SwedishPersonalIdentityNumberParts parts)
+        private static bool TryParseShortPattern(string personalIdentityNumber, int parseYear, out SwedishPersonalIdentityNumberParts parts)
         {
             var pattern = new Regex(@"^" +
                             @"(?<year>[0-9]{2})" +
@@ -45,7 +45,7 @@ namespace ActiveLogin.Identity.Swedish
 
             var partsFromMatch = GetPartsFromMatch(match);
             var delimiter = GetStringValue(match, "delimiter");
-            var fullYear = GetFullYear(partsFromMatch.Year, partsFromMatch.Month, partsFromMatch.Day, delimiter, currentYear);
+            var fullYear = GetFullYear(partsFromMatch.Year, partsFromMatch.Month, partsFromMatch.Day, delimiter, parseYear);
         
             parts = new SwedishPersonalIdentityNumberParts(fullYear, partsFromMatch.Month, partsFromMatch.Day, partsFromMatch.BirthNumber, partsFromMatch.Checksum);
             return true;
@@ -97,13 +97,13 @@ namespace ActiveLogin.Identity.Swedish
             return longPatternMatch.Groups[groupName].Value;
         }
 
-        private static int GetFullYear(int shortYear, int month, int day, string delimiter, DateTime currentYear)
+        private static int GetFullYear(int shortYear, int month, int day, string delimiter, int parseYear)
         {
-            var currentCentury = (currentYear.Year / 100) * 100;
+            var currentCentury = (parseYear / 100) * 100;
             var fullYear = currentCentury + shortYear;
 
             var dateOfBirth = new DateTime(fullYear, month, day, 0, 0, 0, DateTimeKind.Utc);
-            if (dateOfBirth.Year > currentYear.Year)
+            if (dateOfBirth.Year > parseYear)
             {
                 dateOfBirth = dateOfBirth.AddYears(-100);
             }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -19,7 +19,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 1912)]
         public void Parses_Year_From_Short_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2012_01_01);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2012_01_01);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -27,7 +27,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("900101+9802", 1890)]
         public void Parses_Year_From_Short_String_When_Year_Is_Exact_100_Years(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, new DateTime(1990, 01, 01));
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, new DateTime(1990, 01, 01));
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -36,7 +36,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("180101-2392", 2018)]
         public void Parses_Year_From_Short_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -101,8 +101,8 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("180101-2392 ", "180101-2392")]
         public void Strips_Leading_And_Trailing_Whitespace_From_Short_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15);
-            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To10DigitString(_date_2018_07_15));
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
+            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
         }
 
         [Theory]
@@ -112,7 +112,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("990913.9801")]
         public void Throws_When_Invalid_Delimiter_From_Short_String(string personalIdentityNumberString)
         {
-            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
@@ -123,7 +123,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 1912)]
         public void Parses_Year_From_Long_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -132,7 +132,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("201801012392", 2018)]
         public void Parses_Year_From_Long_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -197,7 +197,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("199908072391 ", "199908072391")]
         public void Strips_Leading_And_Trailing_Whitespace_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
         }
 
@@ -205,7 +205,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("18990913+9801")]
         public void Throws_When_Plus_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
-            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
@@ -216,7 +216,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("990913.9801")]
         public void Throws_When_Invalid_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
-            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
@@ -226,9 +226,9 @@ namespace ActiveLogin.Identity.Swedish.Test
             var withHyphen = "120211-9986";
             var withPlus = "120211+9986";
 
-            var pinBeforeTurning100 = SwedishPersonalIdentityNumber.Parse(withHyphen, new DateTime(2011, 1, 1));
-            var pinOnYearTurning100 = SwedishPersonalIdentityNumber.Parse(withPlus, new DateTime(2012, 1, 1));
-            var pinAfterTurning100 = SwedishPersonalIdentityNumber.Parse(withPlus, new DateTime(2013, 1, 1));
+            var pinBeforeTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withHyphen, new DateTime(2011, 1, 1));
+            var pinOnYearTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withPlus, new DateTime(2012, 1, 1));
+            var pinAfterTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withPlus, new DateTime(2013, 1, 1));
 
             var expected = SwedishPersonalIdentityNumber.Create(1912, 02, 11, 998, 6);
             Assert.Equal(expected, pinBeforeTurning100);

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -10,8 +10,6 @@ namespace ActiveLogin.Identity.Swedish.Test
     public class SwedishPersonalIdentityNumber_Parse
     {
         private const string InvalidSwedishPersonalIdentityNumberErrorMessage = "Invalid Swedish personal identity number.";
-        private readonly DateTime _date_2018_07_15 = new DateTime(2018, 07, 15);
-        private readonly DateTime _date_2012_01_01 = new DateTime(2012, 01, 01);
 
         [Theory]
         [InlineData("900101+9802", 1890)]
@@ -19,7 +17,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 1912)]
         public void Parses_Year_From_Short_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2012_01_01);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2012);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -27,7 +25,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("900101+9802", 1890)]
         public void Parses_Year_From_Short_String_When_Year_Is_Exact_100_Years(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, new DateTime(1990, 01, 01));
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 1990);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -36,7 +34,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("180101-2392", 2018)]
         public void Parses_Year_From_Short_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -101,8 +99,8 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("180101-2392 ", "180101-2392")]
         public void Strips_Leading_And_Trailing_Whitespace_From_Short_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
-            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
+            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To10DigitStringInSpecificYear(2018));
         }
 
         [Theory]
@@ -112,7 +110,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("990913.9801")]
         public void Throws_When_Invalid_Delimiter_From_Short_String(string personalIdentityNumberString)
         {
-            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15));
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
@@ -123,7 +121,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 1912)]
         public void Parses_Year_From_Long_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -132,7 +130,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("201801012392", 2018)]
         public void Parses_Year_From_Long_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
         }
 
@@ -197,7 +195,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("199908072391 ", "199908072391")]
         public void Strips_Leading_And_Trailing_Whitespace_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
-            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15);
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
         }
 
@@ -205,7 +203,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("18990913+9801")]
         public void Throws_When_Plus_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
-            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15));
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
@@ -216,7 +214,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("990913.9801")]
         public void Throws_When_Invalid_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
-            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, _date_2018_07_15));
+            var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
 
@@ -226,9 +224,9 @@ namespace ActiveLogin.Identity.Swedish.Test
             var withHyphen = "120211-9986";
             var withPlus = "120211+9986";
 
-            var pinBeforeTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withHyphen, new DateTime(2011, 1, 1));
-            var pinOnYearTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withPlus, new DateTime(2012, 1, 1));
-            var pinAfterTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withPlus, new DateTime(2013, 1, 1));
+            var pinBeforeTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withHyphen, 2011);
+            var pinOnYearTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withPlus, 2012);
+            var pinAfterTurning100 = SwedishPersonalIdentityNumber.ParseInSpecificYear(withPlus, 2013);
 
             var expected = SwedishPersonalIdentityNumber.Create(1912, 02, 11, 998, 6);
             Assert.Equal(expected, pinBeforeTurning100);

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
@@ -19,7 +19,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void The_Year_You_Turn_100_Years_Uses_Plus_As_Delimiter(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitString(_date_2012_01_01));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2012_01_01));
         }
 
         [Theory]
@@ -27,7 +27,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void The_Year_You_Turn_100_Years_Uses_Plus_As_Delimiter_Also_Exact_100_Years(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitString(new DateTime(1990, 01, 01)));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(new DateTime(1990, 01, 01)));
         }
 
         [Theory]
@@ -36,7 +36,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Younger_Than_100_Years_Uses_Dash_As_Delimiter(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitString(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
         }
 
         [Theory]
@@ -46,7 +46,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Date_Parts_Has_Leading_Zeroes_String_Has_Leading_Zeroes(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitString(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
         }
 
         [Theory]
@@ -54,7 +54,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_birthNumber_Has_Leading_Zeroes_String_Has_Leading_Zeroes(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitString(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
         }
 
         [Fact]
@@ -62,9 +62,9 @@ namespace ActiveLogin.Identity.Swedish.Test
         {
             var pin = SwedishPersonalIdentityNumber.Create(1912, 02, 11, 998, 6);
 
-            var stringBeforeTurning100 = pin.To10DigitString(new DateTime(2011, 1, 1));
-            var stringOnYearTurning100 = pin.To10DigitString(new DateTime(2012, 1, 1));
-            var stringAfterTurning100 = pin.To10DigitString(new DateTime(2013, 1, 1));
+            var stringBeforeTurning100 = pin.To10DigitStringInSpecificYear(new DateTime(2011, 1, 1));
+            var stringOnYearTurning100 = pin.To10DigitStringInSpecificYear(new DateTime(2012, 1, 1));
+            var stringAfterTurning100 = pin.To10DigitStringInSpecificYear(new DateTime(2013, 1, 1));
 
             var withHyphen = "120211-9986";
             var withPlus = "120211+9986";

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
@@ -9,9 +9,6 @@ namespace ActiveLogin.Identity.Swedish.Test
     /// </remarks>
     public class SwedishPersonalIdentityNumber_To10DigitString
     {
-        private readonly DateTime _date_2018_07_15 = new DateTime(2018, 07, 15);
-        private readonly DateTime _date_2012_01_01 = new DateTime(2012, 01, 01);
-
         [Theory]
         [InlineData(1890, 01, 01, 980, 2, "900101+9802")]
         [InlineData(1899, 09, 13, 980, 1, "990913+9801")]
@@ -19,7 +16,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void The_Year_You_Turn_100_Years_Uses_Plus_As_Delimiter(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2012_01_01));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(2012));
         }
 
         [Theory]
@@ -27,7 +24,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void The_Year_You_Turn_100_Years_Uses_Plus_As_Delimiter_Also_Exact_100_Years(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(new DateTime(1990, 01, 01)));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(1990));
         }
 
         [Theory]
@@ -36,7 +33,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Younger_Than_100_Years_Uses_Dash_As_Delimiter(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(2018));
         }
 
         [Theory]
@@ -46,7 +43,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_Date_Parts_Has_Leading_Zeroes_String_Has_Leading_Zeroes(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(2018));
         }
 
         [Theory]
@@ -54,7 +51,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         public void When_birthNumber_Has_Leading_Zeroes_String_Has_Leading_Zeroes(int year, int month, int day, int birthNumber, int checksum, string expected)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
-            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(_date_2018_07_15));
+            Assert.Equal(expected, personalIdentityNumber.To10DigitStringInSpecificYear(2018));
         }
 
         [Fact]
@@ -62,9 +59,9 @@ namespace ActiveLogin.Identity.Swedish.Test
         {
             var pin = SwedishPersonalIdentityNumber.Create(1912, 02, 11, 998, 6);
 
-            var stringBeforeTurning100 = pin.To10DigitStringInSpecificYear(new DateTime(2011, 1, 1));
-            var stringOnYearTurning100 = pin.To10DigitStringInSpecificYear(new DateTime(2012, 1, 1));
-            var stringAfterTurning100 = pin.To10DigitStringInSpecificYear(new DateTime(2013, 1, 1));
+            var stringBeforeTurning100 = pin.To10DigitStringInSpecificYear(2011);
+            var stringOnYearTurning100 = pin.To10DigitStringInSpecificYear(2012);
+            var stringAfterTurning100 = pin.To10DigitStringInSpecificYear(2013);
 
             var withHyphen = "120211-9986";
             var withPlus = "120211+9986";


### PR DESCRIPTION
Fixes #25.