### PR TITLE
Add missing tests for delimiter

### DIFF
--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -219,5 +219,21 @@ namespace ActiveLogin.Identity.Swedish.Test
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString, _date_2018_07_15));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
+
+        [Fact]
+        public void Same_Number_Will_Use_Different_Delimiter_When_Parsed_On_Or_After_Person_Turns_100()
+        {
+            var withHyphen = "120211-9986";
+            var withPlus = "120211+9986";
+
+            var pinBeforeTurning100 = SwedishPersonalIdentityNumber.Parse(withHyphen, new DateTime(2011, 1, 1));
+            var pinOnYearTurning100 = SwedishPersonalIdentityNumber.Parse(withPlus, new DateTime(2012, 1, 1));
+            var pinAfterTurning100 = SwedishPersonalIdentityNumber.Parse(withPlus, new DateTime(2013, 1, 1));
+
+            var expected = SwedishPersonalIdentityNumber.Create(1912, 02, 11, 998, 6);
+            Assert.Equal(expected, pinBeforeTurning100);
+            Assert.Equal(expected, pinOnYearTurning100);
+            Assert.Equal(expected, pinAfterTurning100);
+        }
     }
 }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
@@ -56,5 +56,21 @@ namespace ActiveLogin.Identity.Swedish.Test
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Create(year, month, day, birthNumber, checksum);
             Assert.Equal(expected, personalIdentityNumber.To10DigitString(_date_2018_07_15));
         }
+
+        [Fact]
+        public void NumberString_Will_Use_Different_Delimiter_When_Executed_On_Or_After_Person_Turns_100()
+        {
+            var pin = SwedishPersonalIdentityNumber.Create(1912, 02, 11, 998, 6);
+
+            var stringBeforeTurning100 = pin.To10DigitString(new DateTime(2011, 1, 1));
+            var stringOnYearTurning100 = pin.To10DigitString(new DateTime(2012, 1, 1));
+            var stringAfterTurning100 = pin.To10DigitString(new DateTime(2013, 1, 1));
+
+            var withHyphen = "120211-9986";
+            var withPlus = "120211+9986";
+            Assert.Equal(withHyphen, stringBeforeTurning100);
+            Assert.Equal(withPlus, stringOnYearTurning100);
+            Assert.Equal(withPlus, stringAfterTurning100);
+        }
     }
 }


### PR DESCRIPTION
Add tests for .Parse(date) and .To10DigitString(date) that verify the requirement that the delimiter will change from a hyphen to a plus from the start of they year when a person turns 100.

The requirement was already implemented, but the tests were missing.