### PR TITLE
Add tests for TryParse

### DIFF
--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_TryParse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_TryParse.cs
@@ -26,5 +26,13 @@ namespace ActiveLogin.Identity.Swedish.Test
             Assert.True(isValid);
             Assert.Equal(SwedishPersonalIdentityNumber.Create(2000, 01, 01, 238, 4), personalIdentityNumber);
         }
+
+        [Fact]
+        public void TryParse_Returns_False_When_Valid_CoordinationNumber()
+        {
+            var isValid = SwedishPersonalIdentityNumber.TryParse("170182-2387", out SwedishPersonalIdentityNumber result);
+
+            Assert.False(isValid);
+        }
     }
 }

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_TryParse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_TryParse.cs
@@ -1,0 +1,30 @@
+using System;
+using Xunit;
+
+namespace ActiveLogin.Identity.Swedish.Test
+{
+    /// <remarks>
+    /// Tested with offical test Personal Identity Numbers from Skatteverket:
+    /// https://skatteverket.entryscape.net/catalog/9/datasets/147
+    /// </remarks>
+    public class SwedishPersonalIdentityNumber_TryParse
+    {
+        [Fact]
+        public void TryParse_Returns_False_And_Outputs_Null_When_Invalid_Day()
+        {
+            var isValid = SwedishPersonalIdentityNumber.TryParse("170199-2388", out SwedishPersonalIdentityNumber personalIdentityNumber);
+
+            Assert.False(isValid);
+            Assert.Null(personalIdentityNumber);
+        }
+
+        [Fact]
+        public void TryParse_Returns_True_And_Outs_PIN_When_Valid_PIN()
+        {
+            var isValid = SwedishPersonalIdentityNumber.TryParse("000101-2384", out SwedishPersonalIdentityNumber personalIdentityNumber);
+
+            Assert.True(isValid);
+            Assert.Equal(SwedishPersonalIdentityNumber.Create(2000, 01, 01, 238, 4), personalIdentityNumber);
+        }
+    }
+}


### PR DESCRIPTION
We had missed to test TryParse. This PR does that. It does not test all combination of inputs, but the aim is to test the specific behavior of what TryParse does (return true and output result if valid, return false and output null if not).