### PR TITLE
Add support for more formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ For more usecases, samples and inspiration; feel free to browse our unit tests a
 
 ## FAQ
 
+### What formats of a Swedish Personal Identity Number do you support parsing?
+
+We consider the following to be valid Swedish Personal Identity Numbers that will be parsed:
+
+#### 10 digit string
+
+* YYMMDD-BBBC
+* YYMMDD+BBBC
+* YYMMDD BBBC _(Treated as YYMMDD-BBBC)_
+* YYMMDDBBBC _(Treated as YYMMDD-BBBC)_
+
+#### 12 digit string
+
+* YYYYMMDDBBBC
+* YYYYMMDD-BBBC _(Treated as YYYYMMDDBBBC)_
+* YYYYMMDD BBBC _(Treated as YYYYMMDDBBBC)_
+
+#### Explanations
+
+* **YY:** Year
+* **MM:** Month
+* **DD:** Day
+* **BBB:** Birth number
+* **C:** Checksum
+
 ### What definition of Swedish Personal Identity Number are the implementations based on?
 
 The implementation is based on the definitions as described here:

--- a/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
+++ b/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
@@ -12,7 +12,7 @@
     <PackageId>ActiveLogin.Identity.Swedish.AspNetCore</PackageId>
 
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc-1</VersionSuffix>
+    <VersionSuffix>rc-2</VersionSuffix>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 

--- a/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
+++ b/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
@@ -13,7 +13,7 @@
     <PackageId>ActiveLogin.Identity.Swedish</PackageId>
 
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>rc-1</VersionSuffix>
+    <VersionSuffix>rc-2</VersionSuffix>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 

--- a/src/ActiveLogin.Identity.Swedish/Parse.fs
+++ b/src/ActiveLogin.Identity.Swedish/Parse.fs
@@ -6,6 +6,7 @@ open System.Text.RegularExpressions
 type Delimiter =
     | Plus
     | Hyphen
+    | Whitespace
 
 type NumberParts =
     { FullYear : int option
@@ -33,6 +34,7 @@ let private buildNumberParts (gs : GroupCollection) =
         |> function
         | Some v when v = "+" -> Some Plus
         | Some v when v = "-" -> Some Hyphen
+        | Some v when v = " " -> Some Whitespace
         | Some _ -> invalidArg "gs" "Invalid delimiter"
         | None -> None
 
@@ -62,7 +64,7 @@ let (|SwedishIdentityNumber|_|) (input : string) =
                   @"((?<fullYear>[0-9]{4})|(?<shortYear>[0-9]{2}))" + 
                   @"(?<month>[0-9]{2})" + 
                   @"(?<day>[0-9]{2})" + 
-                  @"(?<delimiter>[-+]?)" + 
+                  @"(?<delimiter>[-+ ]?)" + 
                   @"(?<birthNumber>[0-9]{3})" + 
                   @"(?<checksum>[0-9]{1})" + 
                   @"$"

--- a/src/ActiveLogin.Identity.Swedish/Parse.fs
+++ b/src/ActiveLogin.Identity.Swedish/Parse.fs
@@ -29,12 +29,17 @@ let private buildNumberParts (gs : GroupCollection) =
         |> Option.map Int32.Parse
 
     let asDelimiter (gs : GroupCollection) =
-        gs
-        |> asString "delimiter"
+        let noneEmptyString str = 
+            match str with
+            | "" -> None
+            | d -> Some d
+
+        gs.["delimiter"].ToString()
+        |> noneEmptyString 
         |> function
-        | Some v when v = "+" -> Some Plus
-        | Some v when v = "-" -> Some Hyphen
-        | Some v when v = " " -> Some Whitespace
+        | Some d when d = "+" -> Some Plus
+        | Some d when d = "-" -> Some Hyphen
+        | Some d when d = " " -> Some Whitespace
         | Some _ -> invalidArg "gs" "Invalid delimiter"
         | None -> None
 
@@ -60,14 +65,9 @@ let private buildNumberParts (gs : GroupCollection) =
 
 let (|SwedishIdentityNumber|_|) (input : string) =
     let matchRegex pattern input = Regex.Match(input, pattern)
-    let pattern = @"^" + 
-                  @"((?<fullYear>[0-9]{4})|(?<shortYear>[0-9]{2}))" + 
-                  @"(?<month>[0-9]{2})" + 
-                  @"(?<day>[0-9]{2})" + 
-                  @"(?<delimiter>[-+ ]?)" + 
-                  @"(?<birthNumber>[0-9]{3})" + 
-                  @"(?<checksum>[0-9]{1})" + 
-                  @"$"
+    let pattern =
+        @"^" + @"((?<fullYear>[0-9]{4})|(?<shortYear>[0-9]{2}))" + @"(?<month>[0-9]{2})" + @"(?<day>[0-9]{2})"
+        + @"(?<delimiter>[-+ ]?)" + @"(?<birthNumber>[0-9]{3})" + @"(?<checksum>[0-9]{1})" + @"$"
     let m = input.Trim() |> matchRegex pattern
     match m.Success with
     | true ->

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -87,8 +87,8 @@ let parseInSpecificYear parseYear str =
 
             let fullYear =
                 match delimiter with
-                | Some Hyphen | None when shortYear <= lastDigitsParseYear -> fullYearGuess
-                | Some Hyphen | None -> fullYearGuess - 100
+                | Some Hyphen | Some Whitespace | None when shortYear <= lastDigitsParseYear -> fullYearGuess
+                | Some Hyphen | Some Whitespace | None -> fullYearGuess - 100
                 | Some Plus when shortYear <= lastDigitsParseYear -> fullYearGuess - 100
                 | Some Plus -> fullYearGuess - 200
             create { Year = fullYear

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -70,7 +70,9 @@ let parseInSpecificYear parseYear str =
     let fromNumberParts parseYear parsed =
         match parsed.FullYear, parsed.ShortYear, parsed.Month, parsed.Day, parsed.Delimiter, parsed.BirthNumber,
               parsed.Checksum with
-        | Some fullYear, None, month, day, None, birthNumber, checksum ->
+        | Some fullYear, None, month, day, None, birthNumber, checksum
+        | Some fullYear, None, month, day, Some Hyphen, birthNumber, checksum
+        | Some fullYear, None, month, day, Some Whitespace, birthNumber, checksum ->
             create { Year = fullYear
                      Month = month
                      Day = day

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
@@ -118,7 +118,7 @@ type SwedishPersonalIdentityNumber(pin : Types.SwedishPersonalIdentityNumber) =
 
     /// <summary>
     /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent 10 digit string representation. The total length, including the separator, will be 11 chars.
-    /// Format is YYMMDDXSSSC, for example <example>990807-2391</example> or <example>120211+9986</example>.
+    /// Format is YYMMDDXBBBC, for example <example>990807-2391</example> or <example>120211+9986</example>.
     /// </summary>
     /// <param name="serializationYear">
     /// The specific year to use when checking if the person has turned / will turn 100 years old.
@@ -133,19 +133,19 @@ type SwedishPersonalIdentityNumber(pin : Types.SwedishPersonalIdentityNumber) =
 
     /// <summary>
     /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent short string representation.
-    /// Format is YYMMDDXSSSC, for example <example>990807-2391</example> or <example>120211+9986</example>.
+    /// Format is YYMMDDXBBBC, for example <example>990807-2391</example> or <example>120211+9986</example>.
     /// </summary>
     member __.To10DigitString() = to10DigitString identityNumber
 
     /// <summary>
     /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent 12 digit string representation.
-    /// Format is YYYYMMDDSSSC, for example <example>19908072391</example> or <example>191202119986</example>.
+    /// Format is YYYYMMDDBBBC, for example <example>19908072391</example> or <example>191202119986</example>.
     /// </summary>
     member __.To12DigitString() = to12DigitString identityNumber
 
     /// <summary>
     /// Converts the value of the current <see cref="SwedishPersonalIdentityNumber" /> object to its equivalent 12 digit string representation.
-    /// Format is YYYYMMDDSSSC, for example <example>19908072391</example> or <example>191202119986</example>.
+    /// Format is YYYYMMDDBBBC, for example <example>19908072391</example> or <example>191202119986</example>.
     /// </summary>
     override __.ToString() = __.To12DigitString()
 

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -104,7 +104,6 @@ namespace ActiveLogin.Identity.Swedish.Test
         }
 
         [Theory]
-        [InlineData("990913 9801")]
         [InlineData("990913—9801")]
         [InlineData("990913_9801")]
         [InlineData("990913.9801")]
@@ -113,8 +112,6 @@ namespace ActiveLogin.Identity.Swedish.Test
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
         }
-
-
 
         [Theory]
         [InlineData("189909139801", 1899)]
@@ -200,6 +197,35 @@ namespace ActiveLogin.Identity.Swedish.Test
         }
 
         [Theory]
+        [InlineData("18990913-9801", "189909139801")]
+        [InlineData("19120211-9986", "191202119986")]
+        [InlineData("19990807-2391", "199908072391")]
+        public void Parses_When_Hyphen_Delimiter_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
+            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
+        }
+
+        [Theory]
+        [InlineData("18990913 9801", "189909139801")]
+        [InlineData("19120211 9986", "191202119986")]
+        [InlineData("19990807 2391", "199908072391")]
+        public void Parses_When_Whitespace_Delimiter_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
+            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
+        }
+
+        [Theory]
+        [InlineData("180101 2392", "201801012392")]
+        [InlineData("990807 2391", "199908072391")]
+        public void Parses_When_Whitespace_Delimiter_From_Short_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
+            Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
+        }
+
+        [Theory]
         [InlineData("18990913+9801")]
         public void Throws_When_Plus_Delimiter_From_Long_String(string personalIdentityNumberString)
         {
@@ -208,7 +234,6 @@ namespace ActiveLogin.Identity.Swedish.Test
         }
 
         [Theory]
-        [InlineData("18990913 9801")]
         [InlineData("990913—9801")]
         [InlineData("990913_9801")]
         [InlineData("990913.9801")]

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -235,9 +235,12 @@ namespace ActiveLogin.Identity.Swedish.Test
 
         [Theory]
         [InlineData("990913—9801")]
+        [InlineData("19990913—9801")]
         [InlineData("990913_9801")]
+        [InlineData("19990913_9801")]
         [InlineData("990913.9801")]
-        public void Throws_When_Invalid_Delimiter_From_12_Digit_String(string personalIdentityNumberString)
+        [InlineData("19990913.9801")]
+        public void Throws_When_Invalid_Delimiter(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Parse.cs
@@ -15,7 +15,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("900101+9802", 1890)]
         [InlineData("990913+9801", 1899)]
         [InlineData("120211+9986", 1912)]
-        public void Parses_Year_From_Short_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_10_Digit_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2012);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -23,7 +23,7 @@ namespace ActiveLogin.Identity.Swedish.Test
 
         [Theory]
         [InlineData("900101+9802", 1890)]
-        public void Parses_Year_From_Short_String_When_Year_Is_Exact_100_Years(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_10_Digit_String_When_Year_Is_Exact_100_Years(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 1990);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -32,7 +32,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [Theory]
         [InlineData("990807-2391", 1999)]
         [InlineData("180101-2392", 2018)]
-        public void Parses_Year_From_Short_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_10_Digit_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -43,7 +43,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 1912)]
         [InlineData("990807-2391", 1999)]
         [InlineData("180101-2392", 2018)]
-        public void Parses_Year_From_Short_String(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_10_Digit_String(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -54,7 +54,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 02)]
         [InlineData("990807-2391", 08)]
         [InlineData("180101-2392", 01)]
-        public void Parses_Month_From_Short_String(string personalIdentityNumberString, int expectedMonth)
+        public void Parses_Month_From_10_Digit_String(string personalIdentityNumberString, int expectedMonth)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedMonth, personalIdentityNumber.Month);
@@ -65,7 +65,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 11)]
         [InlineData("990807-2391", 07)]
         [InlineData("180101-2392", 01)]
-        public void Parses_Day_From_Short_String(string personalIdentityNumberString, int expectedDay)
+        public void Parses_Day_From_10_Digit_String(string personalIdentityNumberString, int expectedDay)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedDay, personalIdentityNumber.Day);
@@ -76,7 +76,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 998)]
         [InlineData("990807-2391", 239)]
         [InlineData("180101-2392", 239)]
-        public void Parses_BirthNumber_From_Short_String(string personalIdentityNumberString, int expectedBirthNumber)
+        public void Parses_BirthNumber_From_10_Digit_String(string personalIdentityNumberString, int expectedBirthNumber)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedBirthNumber, personalIdentityNumber.BirthNumber);
@@ -87,7 +87,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("120211+9986", 6)]
         [InlineData("990807-2391", 1)]
         [InlineData("180101-2392", 2)]
-        public void Parses_Checksum_From_Short_String(string personalIdentityNumberString, int expectedChecksum)
+        public void Parses_Checksum_From_10_Digit_String(string personalIdentityNumberString, int expectedChecksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedChecksum, personalIdentityNumber.Checksum);
@@ -97,7 +97,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData(" 990913+9801 ", "990913+9801")]
         [InlineData(" 990807-2391", "990807-2391")]
         [InlineData("180101-2392 ", "180101-2392")]
-        public void Strips_Leading_And_Trailing_Whitespace_From_Short_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        public void Strips_Leading_And_Trailing_Whitespace_From_10_Digit_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To10DigitStringInSpecificYear(2018));
@@ -107,7 +107,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("990913—9801")]
         [InlineData("990913_9801")]
         [InlineData("990913.9801")]
-        public void Throws_When_Invalid_Delimiter_From_Short_String(string personalIdentityNumberString)
+        public void Throws_When_Invalid_Delimiter_From_10_Digit_String(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
@@ -116,7 +116,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [Theory]
         [InlineData("189909139801", 1899)]
         [InlineData("191202119986", 1912)]
-        public void Parses_Year_From_Long_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_12_Digit_String_When_Plus_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -125,7 +125,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [Theory]
         [InlineData("199908072391", 1999)]
         [InlineData("201801012392", 2018)]
-        public void Parses_Year_From_Long_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_12_Digit_String_When_Dash_Is_Delimiter(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -136,7 +136,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 1912)]
         [InlineData("199908072391", 1999)]
         [InlineData("201801012392", 2018)]
-        public void Parses_Year_From_Long_String(string personalIdentityNumberString, int expectedYear)
+        public void Parses_Year_From_12_Digit_String(string personalIdentityNumberString, int expectedYear)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedYear, personalIdentityNumber.Year);
@@ -147,7 +147,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 02)]
         [InlineData("199908072391", 08)]
         [InlineData("201801012392", 01)]
-        public void Parses_Month_From_Long_String(string personalIdentityNumberString, int expectedMonth)
+        public void Parses_Month_From_12_Digit_String(string personalIdentityNumberString, int expectedMonth)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedMonth, personalIdentityNumber.Month);
@@ -158,7 +158,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 11)]
         [InlineData("199908072391", 07)]
         [InlineData("201801012392", 01)]
-        public void Parses_Day_From_Long_String(string personalIdentityNumberString, int expectedDay)
+        public void Parses_Day_From_12_Digit_String(string personalIdentityNumberString, int expectedDay)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedDay, personalIdentityNumber.Day);
@@ -169,7 +169,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 998)]
         [InlineData("199908072391", 239)]
         [InlineData("201801012392", 239)]
-        public void Parses_BirthNumber_From_Long_String(string personalIdentityNumberString, int expectedBirthNumber)
+        public void Parses_BirthNumber_From_12_Digit_String(string personalIdentityNumberString, int expectedBirthNumber)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedBirthNumber, personalIdentityNumber.BirthNumber);
@@ -180,7 +180,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("191202119986", 6)]
         [InlineData("199908072391", 1)]
         [InlineData("201801012392", 2)]
-        public void Parses_Checksum_From_Long_String(string personalIdentityNumberString, int expectedChecksum)
+        public void Parses_Checksum_From_12_Digit_String(string personalIdentityNumberString, int expectedChecksum)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
             Assert.Equal(expectedChecksum, personalIdentityNumber.Checksum);
@@ -190,7 +190,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData(" 189909139801 ", "189909139801")]
         [InlineData(" 191202119986", "191202119986")]
         [InlineData("199908072391 ", "199908072391")]
-        public void Strips_Leading_And_Trailing_Whitespace_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        public void Strips_Leading_And_Trailing_Whitespace_From_12_Digit_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
@@ -200,7 +200,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("18990913-9801", "189909139801")]
         [InlineData("19120211-9986", "191202119986")]
         [InlineData("19990807-2391", "199908072391")]
-        public void Parses_When_Hyphen_Delimiter_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        public void Parses_When_Hyphen_Delimiter_From_12_Digit_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
@@ -210,7 +210,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("18990913 9801", "189909139801")]
         [InlineData("19120211 9986", "191202119986")]
         [InlineData("19990807 2391", "199908072391")]
-        public void Parses_When_Whitespace_Delimiter_From_Long_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        public void Parses_When_Whitespace_Delimiter_From_12_Digit_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
@@ -219,7 +219,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [Theory]
         [InlineData("180101 2392", "201801012392")]
         [InlineData("990807 2391", "199908072391")]
-        public void Parses_When_Whitespace_Delimiter_From_Short_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
+        public void Parses_When_Whitespace_Delimiter_From_10_Digit_String(string personalIdentityNumberString, string expectedPersonalIdentityNumberString)
         {
             var personalIdentityNumber = SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018);
             Assert.Equal(expectedPersonalIdentityNumberString, personalIdentityNumber.To12DigitString());
@@ -227,7 +227,7 @@ namespace ActiveLogin.Identity.Swedish.Test
 
         [Theory]
         [InlineData("18990913+9801")]
-        public void Throws_When_Plus_Delimiter_From_Long_String(string personalIdentityNumberString)
+        public void Throws_When_Plus_Delimiter_From_12_Digit_String(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);
@@ -237,7 +237,7 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("990913—9801")]
         [InlineData("990913_9801")]
         [InlineData("990913.9801")]
-        public void Throws_When_Invalid_Delimiter_From_Long_String(string personalIdentityNumberString)
+        public void Throws_When_Invalid_Delimiter_From_12_Digit_String(string personalIdentityNumberString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SwedishPersonalIdentityNumber.ParseInSpecificYear(personalIdentityNumberString, 2018));
             Assert.Contains(InvalidSwedishPersonalIdentityNumberErrorMessage, ex.Message);


### PR DESCRIPTION
This PR adds support for these formats:

#### 10 digit string

* YYMMDD BBBC _(Treated as YYMMDD-BBBC)_

#### 12 digit string

* YYYYMMDD-BBBC _(Treated as YYYYMMDDBBBC)_
* YYYYMMDD BBBC _(Treated as YYYYMMDDBBBC)_