### PR TITLE
Simplify internal delimiter model.

### DIFF
--- a/src/ActiveLogin.Identity.Swedish/Parse.fs
+++ b/src/ActiveLogin.Identity.Swedish/Parse.fs
@@ -6,14 +6,13 @@ open System.Text.RegularExpressions
 type Delimiter =
     | Plus
     | Hyphen
-    | Whitespace
 
 type NumberParts =
     { FullYear : int option
       ShortYear : int option
       Month : int
       Day : int
-      Delimiter : Delimiter option
+      Delimiter : Delimiter
       BirthNumber : int
       Checksum : int }
 
@@ -29,19 +28,14 @@ let private buildNumberParts (gs : GroupCollection) =
         |> Option.map Int32.Parse
 
     let asDelimiter (gs : GroupCollection) =
-        let noneEmptyString str = 
-            match str with
-            | "" -> None
-            | d -> Some d
 
-        gs.["delimiter"].ToString()
-        |> noneEmptyString 
+        gs
+        |> asString "delimiter"
         |> function
-        | Some d when d = "+" -> Some Plus
-        | Some d when d = "-" -> Some Hyphen
-        | Some d when d = " " -> Some Whitespace
-        | Some _ -> invalidArg "gs" "Invalid delimiter"
-        | None -> None
+        | Some d when d = "+" -> Plus
+        | Some d when d = "-" || d = " " -> Hyphen
+        | None -> Hyphen
+        | _ -> invalidArg "gs" "Invalid delimiter"
 
     { FullYear = asInt "fullYear" gs
       ShortYear = asInt "shortYear" gs

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -70,9 +70,7 @@ let parseInSpecificYear parseYear str =
     let fromNumberParts parseYear parsed =
         match parsed.FullYear, parsed.ShortYear, parsed.Month, parsed.Day, parsed.Delimiter, parsed.BirthNumber,
               parsed.Checksum with
-        | Some fullYear, None, month, day, None, birthNumber, checksum
-        | Some fullYear, None, month, day, Some Hyphen, birthNumber, checksum
-        | Some fullYear, None, month, day, Some Whitespace, birthNumber, checksum ->
+        | Some fullYear, None, month, day, Hyphen, birthNumber, checksum ->
             create { Year = fullYear
                      Month = month
                      Day = day
@@ -87,10 +85,10 @@ let parseInSpecificYear parseYear str =
 
             let fullYear =
                 match delimiter with
-                | Some Hyphen | Some Whitespace | None when shortYear <= lastDigitsParseYear -> fullYearGuess
-                | Some Hyphen | Some Whitespace | None -> fullYearGuess - 100
-                | Some Plus when shortYear <= lastDigitsParseYear -> fullYearGuess - 100
-                | Some Plus -> fullYearGuess - 200
+                | Hyphen when shortYear <= lastDigitsParseYear -> fullYearGuess
+                | Hyphen -> fullYearGuess - 100
+                | Plus when shortYear <= lastDigitsParseYear -> fullYearGuess - 100
+                | Plus -> fullYearGuess - 200
             create { Year = fullYear
                      Month = month
                      Day = day


### PR DESCRIPTION
After we implemented support for whitespace as a delimiter for personal identity numbers, I realised that our domain model for the delimiter is unnecessarily complicated. Internally we our only concerned with whether the person is 100 (=> plus) or under (=> dash, hyphen, whitespace or maybe something else).
Today we have modeled the delimiter as:

```
type Delimiter =
    | Plus
    | Hyphen
    | Whitespace
```

It is also wrapped in an option so it can be None (when there is no delimiter). This means we have to pattern match on several cases for the delimiter. This is one example:

``` 
match parsed.FullYear, parsed.ShortYear, parsed.Month, parsed.Day, parsed.Delimiter, parsed.BirthNumber, parsed.Checksum with
| Some fullYear, None, month, day, None, birthNumber, checksum
| Some fullYear, None, month, day, Some Hyphen, birthNumber, checksum
| Some fullYear, None, month, day, Some Whitespace, birthNumber, checksum 
    -> …some logic
```

We can simplify this by changing our domain model to the only relevant cases and not wrap it in an option:

```
type Delimiter =
    | Plus
    | Hyphen
```

Then the pattern match becomes simpler and we only have one case for Hyphen:

```
match parsed.FullYear, parsed.ShortYear, parsed.Month, parsed.Day, parsed.Delimiter, parsed.BirthNumber, parsed.Checksum with
| Some fullYear, None, month, day, Hyphen, birthNumber, checksum 
    -> ...some logic
```

So internally the Delimiter type is actually just a selector for what business logic we want evaluated; That for a person above 100 years of age, or for one younger than 100. Maybe the type should be called something else and not Delimiter, I just cannot think of a better name for the type right now. Suggestions are welcome. 

This means that we can easily support more delimiter types, when we do the regex-parsing we just map it to the correct case (Hyphen or Plus) and no other internal logic needs to change. 
Today if we were to add support a new delimiter type (e.g. an asterisk) we have to update the Delimiter type with a new case, and update all pattern matches for this new case.

No external API is changed because of this PR since the Delimiter is an internal type.