### PR TITLE
Fix for getAgeHint

### DIFF
--- a/samples/ConsoleSample.FSharp/Program.fs
+++ b/samples/ConsoleSample.FSharp/Program.fs
@@ -27,6 +27,7 @@ let parseAndPrintPersonalIdentityNumber str =
     let printAgeHint pin =
         pin
         |> SwedishPersonalIdentityNumber.Hints.getAgeHintOnDate DateTime.UtcNow
+        |> Option.defaultValue 0
         |> printfn "SwedishPersonalIdentityNumber.Hints.getAgeHintOnDate: %i"
 
     let printGenderHint pin =

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -121,7 +121,6 @@ module Hints =
             let months = 12 * (onDate.Year - dateOfBirth.Year) + (onDate.Month - dateOfBirth.Month)
             match onDate.Day < dateOfBirth.Day with
             | true ->
-                let days = DateTime.DaysInMonth(dateOfBirth.Year, dateOfBirth.Month) - dateOfBirth.Day + onDate.Day
                 let years = (months - 1) / 12
                 years |> Some
             | false -> months / 12 |> Some

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -108,11 +108,24 @@ module Hints =
     let getDateOfBirthHint (pin : SwedishPersonalIdentityNumber) =
         DateTime(pin.Year |> Year.value, pin.Month |> Month.value, pin.Day |> Day.value, 0, 0, 0, DateTimeKind.Utc)
 
-    let getAgeHintOnDate (date : DateTime) pin =
+    let getAgeHintOnDate_old (date : DateTime) pin =
         let dateOfBirth = getDateOfBirthHint pin
         let age = date.Year - dateOfBirth.Year
         if date.DayOfYear < dateOfBirth.DayOfYear then age - 1
         else age
+
+    let getAgeHintOnDate (onDate : DateTime) pin =
+        let dateOfBirth = getDateOfBirthHint pin
+        match onDate >= dateOfBirth with
+        | true ->
+            let months = 12 * (onDate.Year - dateOfBirth.Year) + (onDate.Month - dateOfBirth.Month)
+            match onDate.Day < dateOfBirth.Day with
+            | true ->
+                let days = DateTime.DaysInMonth(dateOfBirth.Year, dateOfBirth.Month) - dateOfBirth.Day + onDate.Day
+                let years = (months - 1) / 12
+                years |> Some
+            | false -> months / 12 |> Some
+        | false -> None
 
     let getAgeHint pin = getAgeHintOnDate DateTime.UtcNow pin
 

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -108,12 +108,12 @@ module Hints =
     let getDateOfBirthHint (pin : SwedishPersonalIdentityNumber) =
         DateTime(pin.Year |> Year.value, pin.Month |> Month.value, pin.Day |> Day.value, 0, 0, 0, DateTimeKind.Utc)
 
-    let getAgeHintOnDate (onDate : DateTime) pin =
+    let getAgeHintOnDate (date : DateTime) pin =
         let dateOfBirth = getDateOfBirthHint pin
-        match onDate >= dateOfBirth with
+        match date >= dateOfBirth with
         | true ->
-            let months = 12 * (onDate.Year - dateOfBirth.Year) + (onDate.Month - dateOfBirth.Month)
-            match onDate.Day < dateOfBirth.Day with
+            let months = 12 * (date.Year - dateOfBirth.Year) + (date.Month - dateOfBirth.Month)
+            match date.Day < dateOfBirth.Day with
             | true ->
                 let years = (months - 1) / 12
                 years |> Some

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -108,12 +108,6 @@ module Hints =
     let getDateOfBirthHint (pin : SwedishPersonalIdentityNumber) =
         DateTime(pin.Year |> Year.value, pin.Month |> Month.value, pin.Day |> Day.value, 0, 0, 0, DateTimeKind.Utc)
 
-    let getAgeHintOnDate_old (date : DateTime) pin =
-        let dateOfBirth = getDateOfBirthHint pin
-        let age = date.Year - dateOfBirth.Year
-        if date.DayOfYear < dateOfBirth.DayOfYear then age - 1
-        else age
-
     let getAgeHintOnDate (onDate : DateTime) pin =
         let dateOfBirth = getDateOfBirthHint pin
         match onDate >= dateOfBirth with

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
@@ -195,8 +195,8 @@ type SwedishPersonalIdentityNumberHintExtensions() =
     static member GetAgeHint(pin : SwedishPersonalIdentityNumber, date : DateTime) =
         Hints.getAgeHintOnDate date pin.IdentityNumber
         |> function
-        | i when i < 0 -> invalidArg "pin" "The person is not yet born."
-        | i -> i
+        | None -> invalidArg "pin" "The person is not yet born."
+        | Some i -> i
 
     /// <summary>
     /// Get the age of the person according to the date in the personal identity number.
@@ -206,5 +206,5 @@ type SwedishPersonalIdentityNumberHintExtensions() =
     static member GetAgeHint(pin : SwedishPersonalIdentityNumber) =
         Hints.getAgeHint pin.IdentityNumber
         |> function
-        | i when i < 0 -> invalidArg "pin" "The person is not yet born."
-        | i -> i
+        | None -> invalidArg "pin" "The person is not yet born."
+        | Some i -> i

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetAgeHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetAgeHint.cs
@@ -63,16 +63,16 @@ namespace ActiveLogin.Identity.Swedish.Test
         [InlineData("201703052397", "20180305", 1)]
         [InlineData("201703052397", "20190304", 1)]
         [InlineData("201703052397", "20190305", 2)]
-        [InlineData("201703052397", "20200304", 2)] // Fails. Actual 3
+        [InlineData("201703052397", "20200304", 2)]
         [InlineData("201703052397", "20200305", 3)]
 
         // Birth leap year, after leap day
         [InlineData("201603102383", "20170309", 0)]
-        [InlineData("201603102383", "20170310", 1)] // Fails. Actual 0
+        [InlineData("201603102383", "20170310", 1)]
         [InlineData("201603102383", "20180309", 1)]
-        [InlineData("201603102383", "20180310", 2)] // Fails. Actual 1
+        [InlineData("201603102383", "20180310", 2)]
         [InlineData("201603102383", "20190309", 2)]
-        [InlineData("201603102383", "20190310", 3)] // Fails. Actual 2
+        [InlineData("201603102383", "20190310", 3)]
         [InlineData("201603102383", "20200309", 3)]
         [InlineData("201603102383", "20200310", 4)]
 


### PR DESCRIPTION
fixes #59

> It seems to be a bug in GetAgeHint.
It seems to return wrong age for some combinations of identity number and dates.
Probably due to usage of DateTime.DayOfYear without taking into account it returns different day for same date (after leap day) depending on leap year or not (https://docs.microsoft.com/en-us/dotnet/api/system.datetime.dayofyear?view=netcore-2.1)

@PeterOrneholm maybe you can review?