### PR TITLE
Test for no constructor

### DIFF
--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
@@ -10,7 +10,7 @@ open System.Runtime.InteropServices //for OutAttribute
 /// https://en.wikipedia.org/wiki/Personal_identity_number_(Sweden)
 /// https://sv.wikipedia.org/wiki/Personnummer_i_Sverige
 /// </summary>
-type SwedishPersonalIdentityNumber(pin : Types.SwedishPersonalIdentityNumber) =
+type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNumber) =
     let identityNumber = pin
     member internal __.IdentityNumber = identityNumber
 

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Constructor.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Constructor.cs
@@ -9,9 +9,18 @@ namespace ActiveLogin.Identity.Swedish.Test
     public class SwedishPersonalIdentityNumber_Constructor
     {
         [Fact]
-        public void Should_Have_No_Public_Constructor()
+        public void CSharp_Should_Have_No_Public_Constructor()
         {
             var type = typeof(SwedishPersonalIdentityNumber);
+            var constructors = type.GetConstructors();
+
+            Assert.Empty(constructors);
+        }
+
+        [Fact]
+        public void FSharp_Should_Have_No_Public_Constructor()
+        {
+            var type = typeof(FSharp.SwedishPersonalIdentityNumber);
             var constructors = type.GetConstructors();
 
             Assert.Empty(constructors);

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Constructor.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Constructor.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace ActiveLogin.Identity.Swedish.Test
+{
+    /// <remarks>
+    /// Tested with offical test Personal Identity Numbers from Skatteverket:
+    /// https://skatteverket.entryscape.net/catalog/9/datasets/147
+    /// </remarks>
+    public class SwedishPersonalIdentityNumber_Constructor
+    {
+        [Fact]
+        public void Should_Have_No_Public_Constructor()
+        {
+            var type = typeof(SwedishPersonalIdentityNumber);
+            var constructors = type.GetConstructors();
+
+            Assert.Empty(constructors);
+        }
+    }
+}


### PR DESCRIPTION
Test that there are no public constructors, instead use `.Create(...)`.