### PR TITLE
Move Hint-extensions to a new namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ SwedishPersonalIdentityNumber
 
 #### Hints
 
-Some data, such as DateOfBirth, Age and Gender can't be garanteed to reflect the truth due to the limited quantity of personal identity numbers per day.
-Therefore they are exposed as extension methods and are suffixed with `Hint` to reflect this.
+Some data, such as DateOfBirth, Age and Gender can't be guaranteed to reflect the truth due to the limited quantity of personal identity numbers per day.
+Therefore they are exposed as extension methods in the C# api and are suffixed with `Hint` to reflect this. They are also placed in a separate namespace `ActiveLogin.Identity.Swedish.Extensions`. In the F# api these functions are available in the `ActiveLogin.Identity.Swedish.FSharp.SwedishPersonalIdentityNumber.Hints` module.
 
 #### ASP.NET Core MVC
 
-If used to validate input in an ASP.NET Core MVC project, the `SwedishPersonalIdentityNumberAttribute` can be used  like this:
+If used to validate input in an ASP.NET Core MVC project, the `SwedishPersonalIdentityNumberAttribute` can be used like this:
 
 ```c#
 public class SampleDataModel

--- a/samples/ConsoleSample.CSharp/Program.cs
+++ b/samples/ConsoleSample.CSharp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ActiveLogin.Identity.Swedish;
+using ActiveLogin.Identity.Swedish.Extensions;
 
 namespace ConsoleSample
 {

--- a/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
+++ b/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="Parse.fs" />
     <Compile Include="SwedishPersonalIdentityNumber.fs" />
     <Compile Include="SwedishPersonalIdentityNumberCSharp.fs" />
+    <Compile Include="SwedishPersonalIdentityNumberCSharpHintExtensions.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
@@ -11,7 +11,7 @@ open System.Runtime.InteropServices //for OutAttribute
 /// https://sv.wikipedia.org/wiki/Personnummer_i_Sverige
 /// </summary>
 [<CompiledName("SwedishPersonalIdentityNumber")>]
-type SwedishPersonalIdentityNumberCSharp private(pin : Types.SwedishPersonalIdentityNumber) =
+type SwedishPersonalIdentityNumberCSharp private(pin : SwedishPersonalIdentityNumber) =
     let identityNumber = pin
 
     /// <summary>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
@@ -10,7 +10,8 @@ open System.Runtime.InteropServices //for OutAttribute
 /// https://en.wikipedia.org/wiki/Personal_identity_number_(Sweden)
 /// https://sv.wikipedia.org/wiki/Personnummer_i_Sverige
 /// </summary>
-type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNumber) =
+[<CompiledName("SwedishPersonalIdentityNumber")>]
+type SwedishPersonalIdentityNumberCSharp private(pin : Types.SwedishPersonalIdentityNumber) =
     let identityNumber = pin
 
     /// <summary>
@@ -32,7 +33,7 @@ type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNu
                      BirthNumber = birthNumber
                      Checksum = checksum }
             |> Error.handle
-        SwedishPersonalIdentityNumber(pin)
+        SwedishPersonalIdentityNumberCSharp(pin)
 
     member internal __.IdentityNumber = identityNumber
 
@@ -77,7 +78,7 @@ type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNu
         result { let! year = parseYear |> Year.create
                  return! parseInSpecificYear year s }
         |> Error.handle
-        |> SwedishPersonalIdentityNumber
+        |> SwedishPersonalIdentityNumberCSharp
 
     /// <summary>
     /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent.
@@ -88,7 +89,7 @@ type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNu
     static member Parse(s) =
         parse s
         |> Error.handle
-        |> SwedishPersonalIdentityNumber
+        |> SwedishPersonalIdentityNumberCSharp
 
     /// <summary>
     /// Converts the string representation of the personal identity number to its <see cref="SwedishPersonalIdentityNumber"/> equivalent  and returns a value that indicates whether the conversion succeeded.
@@ -102,13 +103,13 @@ type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNu
     /// </param>
     /// <param name="parseResult">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
     static member TryParseInSpecificYear((s : string), (parseYear : int),
-                                         [<Out>] parseResult : SwedishPersonalIdentityNumber byref) =
+                                         [<Out>] parseResult : SwedishPersonalIdentityNumberCSharp byref) =
         let pin = result { let! year = parseYear |> Year.create
                            return! parseInSpecificYear year s }
         match pin with
         | Error _ -> false
         | Ok pin ->
-            parseResult <- (pin |> SwedishPersonalIdentityNumber)
+            parseResult <- (pin |> SwedishPersonalIdentityNumberCSharp)
             true
 
     /// <summary>
@@ -116,12 +117,12 @@ type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNu
     /// </summary>
     /// <param name="s">A string representation of the Swedish personal identity number to parse.</param>
     /// <param name="parseResult">If valid, an instance of <see cref="SwedishPersonalIdentityNumber"/></param>
-    static member TryParse((s : string), [<Out>] parseResult : SwedishPersonalIdentityNumber byref) =
+    static member TryParse((s : string), [<Out>] parseResult : SwedishPersonalIdentityNumberCSharp byref) =
         let pin = parse s
         match pin with
         | Error _ -> false
         | Ok pin ->
-            parseResult <- (pin |> SwedishPersonalIdentityNumber)
+            parseResult <- (pin |> SwedishPersonalIdentityNumberCSharp)
             true
 
     /// <summary>
@@ -162,57 +163,12 @@ type SwedishPersonalIdentityNumber private(pin : Types.SwedishPersonalIdentityNu
     /// <returns>true if <paramref name="value">value</paramref> is an instance of <see cref="SwedishPersonalIdentityNumber"></see> and equals the value of this instance; otherwise, false.</returns>
     override __.Equals(b) =
         match b with
-        | :? SwedishPersonalIdentityNumber as pin -> identityNumber = pin.IdentityNumber
+        | :? SwedishPersonalIdentityNumberCSharp as pin -> identityNumber = pin.IdentityNumber
         | _ -> false
 
     /// <summary>Returns the hash code for this instance.</summary>
     /// <returns>A 32-bit signed integer hash code.</returns>
     override __.GetHashCode() = hash identityNumber
 
-    static member op_Equality (left: SwedishPersonalIdentityNumber, right: SwedishPersonalIdentityNumber) =
+    static member op_Equality (left: SwedishPersonalIdentityNumberCSharp, right: SwedishPersonalIdentityNumberCSharp) =
         left.IdentityNumber = right.IdentityNumber
-
-open System.Runtime.CompilerServices
-
-[<Extension>]
-type SwedishPersonalIdentityNumberHintExtensions() =
-
-    /// <summary>
-    /// Date of birth for the person according to the personal identity number.
-    /// Not always the actual date of birth due to the limited quantity of personal identity numbers per day.
-    /// </summary>
-    [<Extension>]
-    static member GetDateOfBirthHint(pin : SwedishPersonalIdentityNumber) = Hints.getDateOfBirthHint pin.IdentityNumber
-
-    /// <summary>
-    /// Gender (juridiskt kön) in Sweden according to the last digit of the birth number in the personal identity number.
-    /// Odd number: Male
-    /// Even number: Female
-    /// </summary>
-    [<Extension>]
-    static member GetGenderHint(pin : SwedishPersonalIdentityNumber) = Hints.getGenderHint pin.IdentityNumber
-
-    /// <summary>
-    /// Get the age of the person according to the date in the personal identity number.
-    /// Not always the actual date of birth due to the limited quantity of personal identity numbers per day.
-    /// </summary>
-    /// <param name="pin"></param>
-    /// <param name="date">The date when to calculate the age.</param>
-    /// <returns></returns>
-    [<Extension>]
-    static member GetAgeHint(pin : SwedishPersonalIdentityNumber, date : DateTime) =
-        Hints.getAgeHintOnDate date pin.IdentityNumber
-        |> function
-        | None -> invalidArg "pin" "The person is not yet born."
-        | Some i -> i
-
-    /// <summary>
-    /// Get the age of the person according to the date in the personal identity number.
-    /// Not always the actual date of birth due to the limited quantity of personal identity numbers per day.
-    /// </summary>
-    [<Extension>]
-    static member GetAgeHint(pin : SwedishPersonalIdentityNumber) =
-        Hints.getAgeHint pin.IdentityNumber
-        |> function
-        | None -> invalidArg "pin" "The person is not yet born."
-        | Some i -> i

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharpHintExtensions.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharpHintExtensions.fs
@@ -1,0 +1,50 @@
+namespace ActiveLogin.Identity.Swedish.Extensions
+open System
+open System.Runtime.CompilerServices
+open ActiveLogin.Identity.Swedish
+open ActiveLogin.Identity.Swedish.FSharp
+
+[<Extension>]
+type SwedishPersonalIdentityNumberCSharpHintExtensions() =
+
+    /// <summary>
+    /// Date of birth for the person according to the personal identity number.
+    /// Not always the actual date of birth due to the limited quantity of personal identity numbers per day.
+    /// </summary>
+    [<Extension>]
+    static member GetDateOfBirthHint(pin : SwedishPersonalIdentityNumberCSharp) = 
+        SwedishPersonalIdentityNumber.Hints.getDateOfBirthHint pin.IdentityNumber
+
+    /// <summary>
+    /// Gender (juridiskt kön) in Sweden according to the last digit of the birth number in the personal identity number.
+    /// Odd number: Male
+    /// Even number: Female
+    /// </summary>
+    [<Extension>]
+    static member GetGenderHint(pin : SwedishPersonalIdentityNumberCSharp) = 
+        SwedishPersonalIdentityNumber.Hints.getGenderHint pin.IdentityNumber
+
+    /// <summary>
+    /// Get the age of the person according to the date in the personal identity number.
+    /// Not always the actual date of birth due to the limited quantity of personal identity numbers per day.
+    /// </summary>
+    /// <param name="pin"></param>
+    /// <param name="date">The date when to calculate the age.</param>
+    /// <returns></returns>
+    [<Extension>]
+    static member GetAgeHint(pin : SwedishPersonalIdentityNumberCSharp, date : DateTime) =
+        SwedishPersonalIdentityNumber.Hints.getAgeHintOnDate date pin.IdentityNumber
+        |> function
+        | None -> invalidArg "pin" "The person is not yet born."
+        | Some i -> i
+
+    /// <summary>
+    /// Get the age of the person according to the date in the personal identity number.
+    /// Not always the actual date of birth due to the limited quantity of personal identity numbers per day.
+    /// </summary>
+    [<Extension>]
+    static member GetAgeHint(pin : SwedishPersonalIdentityNumberCSharp) =
+        SwedishPersonalIdentityNumber.Hints.getAgeHint pin.IdentityNumber
+        |> function
+        | None -> invalidArg "pin" "The person is not yet born."
+        | Some i -> i

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetAgeHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetAgeHint.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Xunit;
+using ActiveLogin.Identity.Swedish.Extensions;
 
 namespace ActiveLogin.Identity.Swedish.Test
 {

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetDateOfBirthHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetDateOfBirthHint.cs
@@ -1,5 +1,6 @@
 using System;
 using Xunit;
+using ActiveLogin.Identity.Swedish.Extensions;
 
 namespace ActiveLogin.Identity.Swedish.Test
 {

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetGenderHint.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumberHintExtensions_GetGenderHint.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using ActiveLogin.Identity.Swedish.Extensions;
 
 namespace ActiveLogin.Identity.Swedish.Test
 {


### PR DESCRIPTION
This pull-request moves the Hint-extensions in the C# api to a new namespace. To use the Hints the client now needs to open the `ActiveLogin.Identity.Swedish.Extensions` namespace.

In the F# api these functions are not extensions but are instead placed in a Hints module. Provided that you have already opened `ActiveLogin.Identity.Swedish.FSharp` the functions can be accessed like `SwedishPersonalIdentityNumber.Hints.getDateOfBirthHint`.

I have also renamed the C# type in the source code, adding a CSharp-suffix so it is easier to see when we are using the CSharp-type or the FSharp-type. It uses the `CompiledNameAttribute` so the name of the compiled class will still be SwedishPersonalIdentityNumber. 