### PR TITLE
Add missing nullcheck for equality test

### DIFF
--- a/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
+++ b/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>ActiveLogin.Identity.Swedish.AspNetCore</AssemblyName>
     <PackageId>ActiveLogin.Identity.Swedish.AspNetCore</PackageId>
 
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <!--<VersionSuffix>beta-1</VersionSuffix>-->
     <AssemblyVersion>2.0.0</AssemblyVersion>
     <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
+++ b/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
@@ -13,7 +13,7 @@
     <AssemblyName>ActiveLogin.Identity.Swedish</AssemblyName>
     <PackageId>ActiveLogin.Identity.Swedish</PackageId>
 
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <!--<VersionSuffix>beta-1</VersionSuffix>-->
     <AssemblyVersion>2.0.0</AssemblyVersion>
     <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumberCSharp.fs
@@ -171,4 +171,7 @@ type SwedishPersonalIdentityNumberCSharp private(pin : SwedishPersonalIdentityNu
     override __.GetHashCode() = hash identityNumber
 
     static member op_Equality (left: SwedishPersonalIdentityNumberCSharp, right: SwedishPersonalIdentityNumberCSharp) =
-        left.IdentityNumber = right.IdentityNumber
+        match box left, box right with
+        | (null, null) -> true
+        | (null, _) | (_, null) -> false
+        | _ -> left.IdentityNumber = right.IdentityNumber

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Equals.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Equals.cs
@@ -78,5 +78,25 @@ namespace ActiveLogin.Identity.Swedish.Test
 
             Assert.True(equals);
         }
+
+        [Fact]
+        public void Two_Nulls_Are_Equal_Using_Operator()
+        {
+            Assert.True((SwedishPersonalIdentityNumber)null == (SwedishPersonalIdentityNumber)null);
+        }
+
+        [Fact]
+        public void When_Left_Side_Is_Null_Should_Not_Equal_Using_Operator()
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse("191202119986");
+            Assert.False((SwedishPersonalIdentityNumber)null == personalIdentityNumber);
+        }
+
+        [Fact]
+        public void When_Right_Side_Is_Null_Should_Not_Equal_Using_Operator()
+        {
+            var personalIdentityNumber = SwedishPersonalIdentityNumber.Parse("191202119986");
+            Assert.False(personalIdentityNumber == (SwedishPersonalIdentityNumber)null);
+        }
     }
 }


### PR DESCRIPTION
Bugfix for equality (==) test when one or more operands are null.