### PR TITLE
Feature/stricter interpretation of valid year

### DIFF
--- a/src/ActiveLogin.Identity.Swedish/Parse.fs
+++ b/src/ActiveLogin.Identity.Swedish/Parse.fs
@@ -13,7 +13,7 @@ let parse parseYear =
     let requireNotEmpty str =
         match String.IsNullOrWhiteSpace str with
         | false -> str |> Ok
-        | true when str = null ->
+        | true when isNull str ->
             Null
             |> ArgumentError
             |> Error

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -27,6 +27,19 @@ let private extractValues (pin : SwedishPersonalIdentityNumber) : SwedishPersona
       BirthNumber = pin.BirthNumber |> BirthNumber.value
       Checksum = pin.Checksum |> Checksum.value }
 
+let private validateSerializationYear (serializationYear: Year) (pinYear: Year) =
+    if serializationYear < pinYear 
+    then 
+        "Serialization cannot be a year before the person was born" 
+        |> ArgumentOutOfRangeException 
+        |> raise 
+
+    if (serializationYear |> Year.value) > ((pinYear |> Year.value) + 199)
+    then 
+        "Serialization cannot be a more than 199 years after the person was born" 
+        |> ArgumentOutOfRangeException 
+        |> raise 
+
 /// <summary>
 /// Converts a SwedishPersonalIdentityNumber to its equivalent 10 digit string representation. The total length, including the separator, will be 11 chars. 
 /// </summary>
@@ -38,6 +51,7 @@ let private extractValues (pin : SwedishPersonalIdentityNumber) : SwedishPersona
 /// </param>
 /// <param name="pin">A SwedishPersonalIdentityNumber</param>
 let to10DigitStringInSpecificYear serializationYear (pin : SwedishPersonalIdentityNumber) =
+    validateSerializationYear serializationYear pin.Year
     let delimiter =
         if (serializationYear |> Year.value) - (pin.Year |> Year.value) >= 100 then "+"
         else "-"

--- a/src/ActiveLogin.Identity.Swedish/Types.fs
+++ b/src/ActiveLogin.Identity.Swedish/Types.fs
@@ -59,8 +59,12 @@ module Error =
 type Year = private Year of int
 
 module Year =
+    [<Literal>] 
+    let private MinYear = 1840 // Pins were introduced in 1947 
+    let private maxYear = DateTime.Now.Year + 199
+
     let create year =
-        let isValidYear = year >= DateTime.MinValue.Year && year <= DateTime.MaxValue.Year
+        let isValidYear = year >= MinYear && year <= maxYear
         if isValidYear then
             year
             |> Year

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Constructor.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Constructor.cs
@@ -11,10 +11,19 @@ namespace ActiveLogin.Identity.Swedish.Test
     {
         [Theory]
         [InlineData(-1, 01, 01, 239, 2)]
+        [InlineData(1839, 01, 01, 239, 2)]
         [InlineData(int.MaxValue, 01, 01, 239, 2)]
         public void Throws_When_Invalid_Year(int year, int month, int day, int birthNumber, int checksum)
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new SwedishPersonalIdentityNumber(year, month, day, birthNumber, checksum));
+            Assert.Contains("Invalid year.", ex.Message);
+        }
+
+        [Fact]
+        public void Throws_WhenYearIsMoreThan199YearsInTheFuture()
+        {
+            var year = DateTime.Now.AddYears(200).Year;
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new SwedishPersonalIdentityNumber(year, 01, 01, 239, 2));
             Assert.Contains("Invalid year.", ex.Message);
         }
 

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_To10DigitString.cs
@@ -90,5 +90,25 @@ namespace ActiveLogin.Identity.Swedish.Test
             var personalIdentityNumber = new SwedishPersonalIdentityNumber(2017, 1, 22, 238, 0);
             Assert.Throws<ArgumentOutOfRangeException>(() => personalIdentityNumber.To10DigitStringInSpecificYear(-1));
         }
+
+        [Theory]
+        [InlineData("120211+9986", 1912)]
+        [InlineData("990807-2391", 1999)]
+        public void To10DigitString_WhenParseYearIs200YearsAfterPersonWasBorn_ThrowsArgumentException(string str, int birthYear)
+        {
+            var serializationYear = birthYear + 200;
+            var pin = SwedishPersonalIdentityNumber.Parse(str);
+            Assert.Throws<ArgumentOutOfRangeException>(() => pin.To10DigitStringInSpecificYear(serializationYear ));
+        }
+
+        [Theory]
+        [InlineData("120211+9986", 1912)]
+        [InlineData("990807-2391", 1999)]
+        public void To10DigitString_WhenParseYearIsBeforePersonIsBorn_ThrowsArgumentException(string str, int birthYear)
+        {
+            var serializationYear = birthYear - 1;
+            var pin = SwedishPersonalIdentityNumber.Parse(str);
+            Assert.Throws<ArgumentOutOfRangeException>(() => pin.To10DigitStringInSpecificYear(serializationYear));
+        }
     }
 }


### PR DESCRIPTION
I would like to open up for discussion that we are more strict in what we consider valid years for swedish personal identity number. 

I do not see any value in it being possible to create a pin for years in the full range 1-9999. My proposal is to limit the range even more. 

As a minimum year we could take 1890 which is the minimum year in the available test data, or just to be safe we can go back a little further. e.g. 1840.

For maximum year I propose the currentYear + 199, which coincidentally is the possible valid years for a pin formatted with 10-digits.  