### PR TITLE
Verify that CI build fails for focused tests

### DIFF
--- a/ActiveLogin.Identity.sln
+++ b/ActiveLogin.Identity.sln
@@ -14,6 +14,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution files", "Solution files", "{A62CB923-FBEA-4F05-A776-47F8F7569DA8}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		azure-pipelines.yml = azure-pipelines.yml
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		global.json = global.json
 		LICENSE.md = LICENSE.md

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ActiveLogin.Identity provides parsing and validation of Swedish identities such 
 
 ## Features
 - :id: .NET parser for Swedish Personal Identity Number (Svenskt personnummer)
-- :penguin: Cross platform: Targets .NET Standard 2.0 and .NET Framework 4.6.1
+- :penguin: Cross platform: Targets .NET Standard 2.0
 - :heavy_check_mark: Strong named
 - :lock: GDPR Compliant
 - :calendar: Extracts metadata such as date of birth and gender

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ActiveLogin.Identity
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Build status](https://dev.azure.com/activesolution/ActiveLogin/_apis/build/status/ActiveLogin.Identity)](https://dev.azure.com/activesolution/ActiveLogin/_build/latest?definitionId=154)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://dev.azure.com/activesolution/ActiveLogin/_apis/build/status/ActiveLogin.Identity?branchName=master)](https://activesolution.visualstudio.com/ActiveLogin/_build/latest?definitionId=190&branchName=master)
 
 ActiveLogin.Identity provides parsing and validation of Swedish identities such as Personal Identity Number (svenskt personnummer). Built on NET Standard and packaged as NuGet-packages they are easy to install and use on multiple platforms.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ ActiveLogin.Identity provides parsing and validation of Swedish identities such 
 | [ActiveLogin.Identity.Swedish.AspNetCore](https://github.com/ActiveLogin/ActiveLogin.Identity/tree/master/src/ActiveLogin.Identity.Swedish.AspNetCore) | Validation attributes for ASP.NET Core. | [![NuGet](https://img.shields.io/nuget/v/ActiveLogin.Identity.Swedish.AspNetCore.svg)](https://www.nuget.org/packages/ActiveLogin.Identity.Swedish.AspNetCore/) |
 | [ActiveLogin.Identity.Swedish.TestData](https://github.com/ActiveLogin/ActiveLogin.Identity/tree/master/src/ActiveLogin.Identity.Swedish.TestData) | Provides Swedish Personal Identity Numbers test data. | [![NuGet](https://img.shields.io/nuget/v/ActiveLogin.Identity.Swedish.TestData.svg)](https://www.nuget.org/packages/ActiveLogin.Identity.Swedish.TestData/) |
 
+CI-builds from master of all packages are available in [our Azure DevOps Artifacts feed](https://dev.azure.com/activesolution/ActiveLogin/_packaging?_a=feed&feed=ActiveLogin-CI).
+
 ## Getting started
 
 ### 1. Install the NuGet package

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ActiveLogin.Identity provides parsing and validation of Swedish identities such 
 | ------- | ----------- | ----- |
 | [ActiveLogin.Identity.Swedish](https://github.com/ActiveLogin/ActiveLogin.Identity/tree/master/src/ActiveLogin.Identity.Swedish) | .NET classes handling Personal Identity Number | [![NuGet](https://img.shields.io/nuget/v/ActiveLogin.Identity.Swedish.svg)](https://www.nuget.org/packages/ActiveLogin.Identity.Swedish/) |
 | [ActiveLogin.Identity.Swedish.AspNetCore](https://github.com/ActiveLogin/ActiveLogin.Identity/tree/master/src/ActiveLogin.Identity.Swedish.AspNetCore) | Validation attributes for ASP.NET Core. | [![NuGet](https://img.shields.io/nuget/v/ActiveLogin.Identity.Swedish.AspNetCore.svg)](https://www.nuget.org/packages/ActiveLogin.Identity.Swedish.AspNetCore/) |
+| [ActiveLogin.Identity.Swedish.TestData](https://github.com/ActiveLogin/ActiveLogin.Identity/tree/master/src/ActiveLogin.Identity.Swedish.TestData) | Provides Swedish Personal Identity Numbers test data. | [![NuGet](https://img.shields.io/nuget/v/ActiveLogin.Identity.Swedish.TestData.svg)](https://www.nuget.org/packages/ActiveLogin.Identity.Swedish.TestData/) |
 
 ## Getting started
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ stages:
 
     steps:
     - download: current
-      patterns: '$(sourceArtifactName)'
+      patterns: '$(sourceArtifactName)/**/*'
       artifact: '$(sourceArtifactName)'
 
     - task: DownloadSecureFile@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,138 @@
+# Azure DevOps Pipeline
+
+name: $(Date:yyyyMMdd)$(Rev:r)
+
+trigger:
+- master
+
+stages:
+- stage: Build
+  displayName:  'Build, test and package NuGet packages'
+  jobs:
+  - job: BuildTestPackageNuGet
+    displayName: 'Build'
+    strategy:
+      matrix:
+        Windows:
+          vmImage: 'windows-latest'
+          artifactName: 'nuget-windows'
+        macOS:
+          vmImage: 'macOS-latest'
+          artifactName: 'nuget-macos'
+        Linux:
+          vmImage: 'ubuntu-latest'
+          artifactName: 'nuget-linux'
+      maxParallel: 3
+
+    pool:
+      vmImage: '$(vmImage)'
+
+    variables:
+      dotnetBuildConfiguration: 'Release'
+      dotnetVerbosity: 'Detailed'
+
+      pathToBuildProjects: '**/**/*.*sproj'
+      pathToTestProjects: '**/test/**/*.Test.*sproj'
+      pathToPackProjects: '**/src/**/*.*sproj'
+      pathToNugetPackages: '**/*.nupkg'
+
+      sourceRepositoryBranch: '$(Build.SourceBranchName)'
+      sourceRepositoryCommit: '$(Build.SourceVersion)'
+
+      codesigningTimestamperUrl: 'http://timestamp.digicert.com'
+
+    steps:
+
+    - task: UseDotNet@2
+      displayName: 'Install: .NET Core SDK'
+      inputs:
+        useGlobalJson: true
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet restore'
+      inputs:
+        command: restore
+        projects: '$(pathToBuildProjects)'
+        arguments: '--verbosity $(dotnetVerbosity)'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet build'
+      inputs:
+        command: build
+        projects: '$(pathToBuildProjects)'
+        arguments: '--configuration $(dotnetBuildConfiguration) --verbosity $(dotnetVerbosity)'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet pack: ci'
+      inputs:
+        command: custom
+        custom: pack
+        projects: '$(pathToPackProjects)'
+        arguments: '--output "$(Build.ArtifactStagingDirectory)/ci" --configuration $(dotnetBuildConfiguration) --verbosity $(dotnetVerbosity) /p:Configuration=$(dotnetBuildConfiguration) /p:RepositoryBranch=$(sourceRepositoryBranch) /p:RepositoryCommit=$(sourceRepositoryCommit) /p:VersionSuffix=ci-$(Build.BuildNumber)'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet pack: release'
+      inputs:
+        command: custom
+        custom: pack
+        projects: '$(pathToPackProjects)'
+        arguments: '--output "$(Build.ArtifactStagingDirectory)/release" --configuration $(dotnetBuildConfiguration) --verbosity $(dotnetVerbosity) /p:Configuration=$(dotnetBuildConfiguration) /p:RepositoryBranch=$(sourceRepositoryBranch) /p:RepositoryCommit=$(sourceRepositoryCommit)'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet test'
+      inputs:
+        command: test
+        projects: '$(pathToTestProjects)'
+        arguments: '--configuration $(dotnetBuildConfiguration) --collect "Code coverage"'
+
+    - publish: '$(Build.ArtifactStagingDirectory)'
+      artifact: '$(artifactName)'
+
+- stage: Sign
+  displayName: 'Sign NuGet packages'
+  dependsOn: Build
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  jobs:
+  - job: SignNuGet
+    displayName: 'Sign Windows'
+    pool:
+        vmImage: 'windows-latest'
+
+    variables:
+    - group: Active Login   # Contains codesigningCertPassword: Password for code signing cert
+
+    - name: sourceArtifactName
+      value: 'nuget-windows'
+
+    - name: targetArtifactName
+      value: 'nuget-windows-signed'
+
+    - name: pathToNugetPackages
+      value: '**/*.nupkg'
+
+    - name: codesigningTimestamperUrl
+      value: 'http://timestamp.digicert.com'
+
+    steps:
+    - download: current
+      artifact: '$(sourceArtifactName)'
+
+    - task: DownloadSecureFile@1
+      displayName: 'Download secure file: activesolution-codesigning-cert.pfx'
+      name: codesigningCert
+      inputs:
+        secureFile: 'activesolution-codesigning-cert.pfx'
+
+    - task: NuGetToolInstaller@0
+      displayName: 'Install: NuGet'
+      inputs:
+        versionSpec: 5.3.0
+
+    - task: NuGetCommand@2
+      displayName: 'nuget sign'
+      inputs:
+        command: custom
+        arguments: 'sign "$(Pipeline.Workspace)/$(pathToNugetPackages)" -CertificatePath "$(codesigningCert.secureFilePath)" -CertificatePassword "$(codesigningCertPassword)" -Timestamper "$(codesigningTimestamperUrl)"'
+
+    - publish: '$(Pipeline.Workspace)'
+      artifact: '$(targetArtifactName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,6 @@ stages:
 
     steps:
     - download: current
-      patterns: '$(sourceArtifactName)/**/*'
       artifact: '$(sourceArtifactName)'
 
     - task: DownloadSecureFile@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,7 @@ stages:
 
     steps:
     - download: current
+      patterns: '$(sourceArtifactName)'
       artifact: '$(sourceArtifactName)'
 
     - task: DownloadSecureFile@1
@@ -134,5 +135,5 @@ stages:
         command: custom
         arguments: 'sign "$(Pipeline.Workspace)/$(pathToNugetPackages)" -CertificatePath "$(codesigningCert.secureFilePath)" -CertificatePassword "$(codesigningCertPassword)" -Timestamper "$(codesigningTimestamperUrl)"'
 
-    - publish: '$(Pipeline.Workspace)'
+    - publish: '$(Pipeline.Workspace)/$(sourceArtifactName)'
       artifact: '$(targetArtifactName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,8 @@ trigger:
 - master
 
 stages:
-- stage: Build
-  displayName:  'Build, test and package NuGet packages'
+- stage: BuildNuget
+  displayName:  'Build NuGet packages'
   jobs:
   - job: BuildTestPackageNuGet
     displayName: 'Build'
@@ -88,9 +88,9 @@ stages:
     - publish: '$(Build.ArtifactStagingDirectory)'
       artifact: '$(artifactName)'
 
-- stage: Sign
+- stage: SignNuget
   displayName: 'Sign NuGet packages'
-  dependsOn: Build
+  dependsOn: BuildNuget
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   jobs:
   - job: SignNuGet

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ stages:
 
       pathToBuildProjects: '**/**/*.*sproj'
       pathToTestProjects: '**/test/**/*.Test.*sproj'
+      pathToFSharpTestProjects: '**/test/**/*.Test.fsproj'
       pathToPackProjects: '**/src/**/*.*sproj'
       pathToNugetPackages: '**/*.nupkg'
 
@@ -84,6 +85,13 @@ stages:
         command: test
         projects: '$(pathToTestProjects)'
         arguments: '--configuration $(dotnetBuildConfiguration) --collect "Code coverage"'
+
+    - task: DotNetCoreCLI@2
+      displayName: 'dotnet run (FSharp tests)'
+      inputs:
+        command: test
+        projects: '$(pathToFSharpTestProjects)'
+        arguments: '--configuration $(dotnetBuildConfiguration) --fail-on-focused-tests'
 
     - publish: '$(Build.ArtifactStagingDirectory)'
       artifact: '$(artifactName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ stages:
     - task: DotNetCoreCLI@2
       displayName: 'dotnet run (FSharp tests)'
       inputs:
-        command: test
+        command: run
         projects: '$(pathToFSharpTestProjects)'
         arguments: '--configuration $(dotnetBuildConfiguration) --fail-on-focused-tests'
 

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  "sdk": {
-    "version": "3.1.100-preview1-014459"
-  }
+    "sdk": {
+        "version": "3.1.100-preview2-014569"
+    }
 }

--- a/samples/ConsoleSample.CSharp/ConsoleSample.CSharp.csproj
+++ b/samples/ConsoleSample.CSharp/ConsoleSample.CSharp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/samples/ConsoleSample.FSharp/ConsoleSample.FSharp.fsproj
+++ b/samples/ConsoleSample.FSharp/ConsoleSample.FSharp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
+++ b/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
@@ -1,10 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'==''">netstandard2.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks)</TargetFrameworks>
-        <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)'=='net'">.NETFramework</TargetFrameworkIdentifier>
-        <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)'=='netstandard'">.NETStandard</TargetFrameworkIdentifier>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <NoWarn>CS7035</NoWarn>
@@ -13,9 +10,9 @@
         <AssemblyName>ActiveLogin.Identity.Swedish.AspNetCore</AssemblyName>
         <PackageId>ActiveLogin.Identity.Swedish.AspNetCore</PackageId>
 
-        <VersionPrefix>2.0.2</VersionPrefix>
-        <!--<VersionSuffix>beta-1</VersionSuffix>-->
-        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>beta-1</VersionSuffix>
+        <AssemblyVersion>3.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
         <SignAssembly>true</SignAssembly>
@@ -42,11 +39,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Identity.Swedish.TestData/ActiveLogin.Identity.Swedish.TestData.fsproj
+++ b/src/ActiveLogin.Identity.Swedish.TestData/ActiveLogin.Identity.Swedish.TestData.fsproj
@@ -1,10 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'==''">netstandard2.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks)</TargetFrameworks>
-        <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)'=='net'">.NETFramework</TargetFrameworkIdentifier>
-        <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)'=='netstandard'">.NETStandard</TargetFrameworkIdentifier>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <NoWarn>1701;1702;1591;FS2003</NoWarn>
@@ -13,9 +10,9 @@
         <AssemblyName>ActiveLogin.Identity.Swedish.TestData</AssemblyName>
         <PackageId>ActiveLogin.Identity.Swedish.TestData</PackageId>
 
-        <VersionPrefix>1.0.0</VersionPrefix>
-        <!--<VersionSuffix>beta-1</VersionSuffix>-->
-        <AssemblyVersion>1.0.0</AssemblyVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>alpha-1</VersionSuffix>
+        <AssemblyVersion>3.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
         <SignAssembly>true</SignAssembly>
@@ -42,8 +39,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
+        <PackageReference Update="FSharp.Core" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
+++ b/src/ActiveLogin.Identity.Swedish/ActiveLogin.Identity.Swedish.fsproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'==''">netstandard2.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks)</TargetFrameworks>
-        <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)'=='net'">.NETFramework</TargetFrameworkIdentifier>
-        <TargetFrameworkIdentifier Condition="'$(_ShortFrameworkIdentifier)'=='netstandard'">.NETStandard</TargetFrameworkIdentifier>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <NeutralLanguage>en</NeutralLanguage>
         <NoWarn>1701;1702;1591;FS2003</NoWarn>
@@ -13,9 +10,9 @@
         <AssemblyName>ActiveLogin.Identity.Swedish</AssemblyName>
         <PackageId>ActiveLogin.Identity.Swedish</PackageId>
 
-        <VersionPrefix>2.0.2</VersionPrefix>
-        <!--<VersionSuffix>beta-1</VersionSuffix>-->
-        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <VersionPrefix>3.0.0</VersionPrefix>
+        <VersionSuffix>alpha-1</VersionSuffix>
+        <AssemblyVersion>3.0.0</AssemblyVersion>
         <FileVersion Condition="'$(BUILD_BUILDNUMBER)' != ''">$(VersionPrefix).$(BUILD_BUILDNUMBER)</FileVersion>
 
         <SignAssembly>true</SignAssembly>
@@ -42,8 +39,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
-        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
+        <PackageReference Update="FSharp.Core" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/ActiveLogin.Identity.Swedish.AspNetCore.Test/ActiveLogin.Identity.Swedish.AspNetCore.Test.csproj
+++ b/test/ActiveLogin.Identity.Swedish.AspNetCore.Test/ActiveLogin.Identity.Swedish.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <IsPackable>false</IsPackable>
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AltCover" Version="6.2.727" />
+    <PackageReference Include="AltCover" Version="6.5.739" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/test/ActiveLogin.Identity.Swedish.Benchmarks/ActiveLogin.Identity.Swedish.Benchmarks.fsproj
+++ b/test/ActiveLogin.Identity.Swedish.Benchmarks/ActiveLogin.Identity.Swedish.Benchmarks.fsproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Benchmarkdotnet" Version="0.11.5" />
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Include="Benchmarkdotnet" Version="0.12.0" />
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/ActiveLogin.Identity.Swedish.FSharp.Test.fsproj
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/ActiveLogin.Identity.Swedish.FSharp.Test.fsproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -28,8 +28,7 @@
     <PackageReference Include="FSharp.Core" Version="4.*" />
     <PackageReference Include="Unquote" Version="5.0.0" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_parse.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_parse.fs
@@ -33,7 +33,7 @@ let private isInvalidNumberOfDigits (str: string) =
         |> (fun s -> s.Length <> 10 && s.Length <> 12)
 
 let private validPinTests = testList "valid pins" [
-    testProp "roundtrip for 12 digit string" <| fun (Gen.ValidPin pin) ->
+    ftestProp "roundtrip for 12 digit string" <| fun (Gen.ValidPin pin) ->
         pin
         |> SwedishPersonalIdentityNumber.to12DigitString
         |> SwedishPersonalIdentityNumber.parse =! Ok pin

--- a/test/ActiveLogin.Identity.Swedish.Test/ActiveLogin.Identity.Swedish.Test.csproj
+++ b/test/ActiveLogin.Identity.Swedish.Test/ActiveLogin.Identity.Swedish.Test.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <IsPackable>false</IsPackable>
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AltCover" Version="6.2.727" />
+    <PackageReference Include="AltCover" Version="6.5.739" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
**NOTE: This PR should not be merged, it is only used to test our CI build.**

This branch should fail the CI build since it has focused tests. We must run the F# Expecto tests with the command line argument `--fail-on-focused-tests`.

We can close this PR and remove the branch when we have verified that the tests fails with an error like "It was requested that no focused tests exist, but yet there are 1 focused tests found."  

This can be done by running the tests with `dotnet run --project test/ActiveLogin.Identity.Swedish.FSharp.Test --fail-on-focused-tests`. 
If we need to run the tests with `dotnet test` maybe we need to use a .runsettings file to set this flag.