### PR TITLE
Make CI-build fail if there are focused tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ stages:
       inputs:
         command: test
         projects: '$(pathToTestProjects)'
-        arguments: '--configuration $(dotnetBuildConfiguration) --collect "Code coverage"'
+        arguments: '--configuration $(dotnetBuildConfiguration) --collect "Code coverage" -- Expecto.fail-on-focused-tests=true'
 
     - publish: '$(Build.ArtifactStagingDirectory)'
       artifact: '$(artifactName)'

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_create.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_create.fs
@@ -1,4 +1,5 @@
 /// <remarks>
+
 /// Tested with offical test Personal Identity Numbers from Skatteverket:
 /// https://skatteverket.entryscape.net/catalog/9/datasets/147
 /// </remarks>
@@ -15,7 +16,7 @@ open ActiveLogin.Identity.Swedish.FSharp.TestData
 [<Tests>]
 let tests =
     testList "create" [
-        testProp "roundtrip 12DigitString -> create -> to12DigitString" <| fun (Gen.Valid12Digit str) ->
+        ftestProp "roundtrip 12DigitString -> create -> to12DigitString" <| fun (Gen.Valid12Digit str) ->
             str
             |> Gen.stringToValues
             |> SwedishPersonalIdentityNumber.create

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_create.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_create.fs
@@ -1,5 +1,4 @@
 /// <remarks>
-
 /// Tested with offical test Personal Identity Numbers from Skatteverket:
 /// https://skatteverket.entryscape.net/catalog/9/datasets/147
 /// </remarks>
@@ -16,7 +15,7 @@ open ActiveLogin.Identity.Swedish.FSharp.TestData
 [<Tests>]
 let tests =
     testList "create" [
-        ftestProp "roundtrip 12DigitString -> create -> to12DigitString" <| fun (Gen.Valid12Digit str) ->
+        testProp "roundtrip 12DigitString -> create -> to12DigitString" <| fun (Gen.Valid12Digit str) ->
             str
             |> Gen.stringToValues
             |> SwedishPersonalIdentityNumber.create


### PR DESCRIPTION
Add an argument to dotnet test in azure-pipelines.yml to make the test step fail if there are focused tests in the expecto test suite.

