### PR TITLE
Add C#8 nullable to csproj

### DIFF
--- a/samples/ConsoleSample.CSharp/ConsoleSample.CSharp.csproj
+++ b/samples/ConsoleSample.CSharp/ConsoleSample.CSharp.csproj
@@ -1,14 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\ActiveLogin.Identity.Swedish\ActiveLogin.Identity.Swedish.fsproj" />
-    <ProjectReference Include="..\..\src\ActiveLogin.Identity.Swedish.TestData\ActiveLogin.Identity.Swedish.TestData.fsproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\ActiveLogin.Identity.Swedish\ActiveLogin.Identity.Swedish.fsproj" />
+        <ProjectReference Include="..\..\src\ActiveLogin.Identity.Swedish.TestData\ActiveLogin.Identity.Swedish.TestData.fsproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
+++ b/src/ActiveLogin.Identity.Swedish.AspNetCore/ActiveLogin.Identity.Swedish.AspNetCore.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
         <NeutralLanguage>en</NeutralLanguage>
         <NoWarn>CS7035</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Enforces C# 8 nullable reference types on the csprojects.