### PR TITLE
Add missing inequality operator.

### DIFF
--- a/src/ActiveLogin.Identity.Swedish/SwedishCoordinationNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishCoordinationNumber.fs
@@ -240,3 +240,9 @@ type SwedishCoordinationNumber internal(num : SwedishCoordinationNumberInternal)
         | (null, null) -> true
         | (null, _) | (_, null) -> false
         | _ -> left.IdentityNumber = right.IdentityNumber
+
+    static member op_Inequality (left: SwedishCoordinationNumber, right: SwedishCoordinationNumber) =
+        match box left, box right with
+        | (null, null) -> false
+        | (null, _) | (_, null) -> true
+        | _ -> left.IdentityNumber <> right.IdentityNumber

--- a/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
+++ b/src/ActiveLogin.Identity.Swedish/SwedishPersonalIdentityNumber.fs
@@ -228,3 +228,9 @@ type SwedishPersonalIdentityNumber internal(pin : SwedishPersonalIdentityNumberI
         | (null, null) -> true
         | (null, _) | (_, null) -> false
         | _ -> left.IdentityNumber = right.IdentityNumber
+
+    static member op_Inequality (left: SwedishPersonalIdentityNumber, right: SwedishPersonalIdentityNumber) =
+        match box left, box right with
+        | (null, null) -> false
+        | (null, _) | (_, null) -> true
+        | _ -> left.IdentityNumber <> right.IdentityNumber

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishCoordinationNumber_Equality.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishCoordinationNumber_Equality.fs
@@ -4,6 +4,7 @@
 /// </remarks>
 module ActiveLogin.Identity.Swedish.FSharp.Test.SwedishCoordinationNumber_equality
 
+open ActiveLogin.Identity.Swedish
 open Swensen.Unquote
 open Expecto
 open FsCheck
@@ -15,6 +16,14 @@ let tests = testList "SwedishCoordinationNumber.equality" [
         fun (Gen.CoordNum.TwoEqualCoordNums (num1, num2)) ->
             num1 = num2 =! true
             num2 = num1 =! true
+            SwedishCoordinationNumber.op_Equality(num1, num2) =! true
+            SwedishCoordinationNumber.op_Equality(num2, num1) =! true
+    testProp "identical numbers are not unequal when using operator" <|
+        fun (Gen.CoordNum.TwoEqualCoordNums (num1, num2)) ->
+            num1 <> num2 =! false
+            num2 <> num1 =! false
+            SwedishCoordinationNumber.op_Inequality(num1, num2) =! false
+            SwedishCoordinationNumber.op_Inequality(num2, num1) =! false
     testProp "identical numbers are equal when using .Equals()" <|
         fun (Gen.CoordNum.TwoEqualCoordNums (num1, num2)) ->
             num1.Equals(num2) =! true

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_Equality.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_Equality.fs
@@ -4,6 +4,7 @@
 /// </remarks>
 module ActiveLogin.Identity.Swedish.FSharp.Test.SwedishPersonalIdentityNumber_equality
 
+open ActiveLogin.Identity.Swedish
 open Swensen.Unquote
 open Expecto
 open FsCheck
@@ -15,6 +16,14 @@ let tests = testList "SwedishPersonalIdentityNumber.equality" [
         fun (Gen.Pin.TwoEqualPins (pin1, pin2)) ->
             pin1 = pin2 =! true
             pin2 = pin1 =! true
+            SwedishPersonalIdentityNumber.op_Equality(pin1, pin2) =! true
+            SwedishPersonalIdentityNumber.op_Equality(pin2, pin1) =! true
+    testProp "identical pins are not unequal when using operator" <|
+        fun (Gen.Pin.TwoEqualPins (pin1, pin2)) ->
+            pin1 <> pin2 =! false
+            pin2 <> pin1 =! false
+            SwedishPersonalIdentityNumber.op_Inequality(pin1, pin2) =! false
+            SwedishPersonalIdentityNumber.op_Inequality(pin2, pin1) =! false
     testProp "identical pins are equal when using .Equals()" <|
         fun (Gen.Pin.TwoEqualPins (pin1, pin2)) ->
             pin1.Equals(pin2) =! true

--- a/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Equals.cs
+++ b/test/ActiveLogin.Identity.Swedish.Test/SwedishPersonalIdentityNumber_Equals.cs
@@ -42,6 +42,17 @@ namespace ActiveLogin.Identity.Swedish.Test
         }
 
         [Fact]
+        public void Two_Identical_PIN_Are_Not_Unequal_Using_Operator()
+        {
+            var personalIdentityNumberString = "199908072391";
+            var personalIdentityNumber1 = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
+            var personalIdentityNumber2 = SwedishPersonalIdentityNumber.Parse(personalIdentityNumberString);
+            var notEquals = personalIdentityNumber1 != personalIdentityNumber2;
+
+            Assert.False(notEquals);
+        }
+
+        [Fact]
         public void Two_Different_PIN_Are_Not_Equal_Using_Method()
         {
             var personalIdentityNumber1 = SwedishPersonalIdentityNumber.Parse("199908072391");


### PR DESCRIPTION
This PR fixes #120 .

This adds inequality operators for SwedishPersonalIdentityNumber and SwedishCoordinationNumber to make inequality work as expected when used from C#.