### PR TITLE
Move extensions IsTestNumber to namespace ActiveLogin.Identity.Swedish.

### DIFF
--- a/samples/ConsoleSample.FSharp/Program.fs
+++ b/samples/ConsoleSample.FSharp/Program.fs
@@ -1,8 +1,6 @@
 ﻿module ConsoleSample.FSharp
 
-open System
 open ActiveLogin.Identity.Swedish
-open ActiveLogin.Identity.Swedish.TestData
 open ActiveLogin.Identity.Swedish.Extensions
 
 let samplePins = [ "990913+9801"; "120211+9986"; "990807-2391"; "180101-2392"; "180101.2392" ]
@@ -27,7 +25,7 @@ module SwedishPersonalIdentityNumber =
         printfn "   .GetDateOfBirthHint(): %s" (num.GetDateOfBirthHint().ToShortDateString())
         printfn "   .GetAgeHint(): %O" (num.GetAgeHint())
         printfn "   .GetGenderHint(): %O" (num.GetGenderHint())
-        printfn "   .IsTestNumber(): %O" (num.IsTestNumber())
+        printfn "   .IsTestNumber(): %O" (num.IsTestNumber)
 
 let sampleStrings = samplePins @ sampleCoordinationNumbers @ sampleInvalidNumbers
 

--- a/src/ActiveLogin.Identity.Swedish.TestData/ActiveLogin.Identity.Swedish.TestData.fsproj
+++ b/src/ActiveLogin.Identity.Swedish.TestData/ActiveLogin.Identity.Swedish.TestData.fsproj
@@ -54,6 +54,8 @@
         <None Include="..\..\docs\images\active-login-logo-fingerprint-blue-v2-256x256.png" Pack="True" PackagePath="icon.png" />
         <None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
         <None Include="..\..\README.md" Pack="True" PackagePath="README.md" />
+        <Compile Include="SwedishCoordinationNumberExtensions.fs" />
+        <Compile Include="SwedishPersonalIdentityNumberExtensions.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ActiveLogin.Identity.Swedish.TestData/SwedishCoordinationNumberExtensions.fs
+++ b/src/ActiveLogin.Identity.Swedish.TestData/SwedishCoordinationNumberExtensions.fs
@@ -1,0 +1,17 @@
+namespace ActiveLogin.Identity.Swedish
+
+open System.Runtime.CompilerServices
+open ActiveLogin.Identity.Swedish.TestData
+
+[<Extension>]
+/// Checks if a SwedishCoordinationNumber is a test number
+module SwedishCoordinationNumberTestDataExtensions =
+    [<Extension>]
+    let IsTestNumber(pin : SwedishCoordinationNumber) =
+        SwedishCoordinationNumberTestData.IsTestNumber pin
+
+[<AutoOpen>]
+module SwedishCoordinationNumberFSharpExtensions =
+    type SwedishCoordinationNumber
+        /// Checks if a SwedishCoordinationNumber is a test number
+        with member this.IsTestNumber() = SwedishCoordinationNumberTestData.IsTestNumber this

--- a/src/ActiveLogin.Identity.Swedish.TestData/SwedishPersonalIdentityNumberExtensions.fs
+++ b/src/ActiveLogin.Identity.Swedish.TestData/SwedishPersonalIdentityNumberExtensions.fs
@@ -1,0 +1,17 @@
+namespace ActiveLogin.Identity.Swedish
+
+open System.Runtime.CompilerServices
+open ActiveLogin.Identity.Swedish.TestData
+
+[<Extension>]
+/// Checks if a SwedishPersonalIdentityNumber is a test number
+module SwedishPersonalIdentityNumberExtensions =
+    [<Extension>]
+    let IsTestNumber(pin : SwedishPersonalIdentityNumber) =
+        SwedishPersonalIdentityNumberTestData.IsTestNumber pin
+
+[<AutoOpen>]
+module SwedishPersonalIdentityNumberFSharpExtensions =
+    type SwedishPersonalIdentityNumber
+        /// Checks if a SwedishPersonalIdentityNumber is a test number
+        with member this.IsTestNumber() = SwedishPersonalIdentityNumberTestData.IsTestNumber this

--- a/src/ActiveLogin.Identity.Swedish.TestData/TestData.fs
+++ b/src/ActiveLogin.Identity.Swedish.TestData/TestData.fs
@@ -78,16 +78,6 @@ type SwedishPersonalIdentityNumberTestData() =
         (pin.Year, pin.Month, pin.Day, pin.BirthNumber, pin.Checksum)
         |> isTestNumberTuple
 
-open System.Runtime.CompilerServices
-
-[<Extension>]
-/// Checks if a SwedishPersonalIdentityNumber is a test number
-type SwedishPersonalIdentityNumberTestDataExtensions() =
-    [<Extension>]
-    static member IsTestNumber(pin : SwedishPersonalIdentityNumber) =
-        SwedishPersonalIdentityNumberTestData.IsTestNumber pin
-
-
 module SwedishCoordinationNumberTestDataInternal =
     open AllCoordNums
     let internal shuffledCoordNums() = allCoordNums |> Array.sortBy Random.random
@@ -158,11 +148,3 @@ type SwedishCoordinationNumberTestData() =
         |> toTuple
         |> isTestNumberTuple
 
-open System.Runtime.CompilerServices
-
-[<Extension>]
-/// Checks if a SwedishCoordinationNumber is a test number
-type SwedishCoordinationNumberTestDataExtensions() =
-    [<Extension>]
-    static member IsTestNumber(pin : SwedishCoordinationNumber) =
-        SwedishCoordinationNumberTestData.IsTestNumber pin

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/TestDataTests.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/TestDataTests.fs
@@ -1,6 +1,7 @@
 module ActiveLogin.Identity.Swedish.FSharp.Test.TestDataTests
 open Swensen.Unquote
 open Expecto
+open ActiveLogin.Identity.Swedish
 open ActiveLogin.Identity.Swedish.FSharp.Test.PinTestHelpers
 open ActiveLogin.Identity.Swedish.TestData
 


### PR DESCRIPTION
This PR fixes #128 

@PeterOrneholm Can you verify that the extensions have been moved to the expected namespaces?