### PR TITLE
Fix coordination-number zero day bug

### DIFF
--- a/src/ActiveLogin.Identity.Swedish/Types.fs
+++ b/src/ActiveLogin.Identity.Swedish/Types.fs
@@ -89,8 +89,8 @@ module CoordinationMonth =
 module CoordinationDay =
     let [<Literal>] DayOffset = 60
     let create (Year inYear) (CoordinationMonth inMonth) day =
-        if day = 0 then
-            CoordinationDay DayOffset
+        if day = DayOffset then
+            CoordinationDay DayOffset // Real day = 0, this is valid when the day of date of birth is unknown.
         else
             let daysInMonth =
                 if inMonth = 0 then 31 else DateTime.DaysInMonth(inYear, inMonth)

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishCoordinationNumber_Parse.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishCoordinationNumber_Parse.fs
@@ -108,9 +108,25 @@ let invalidNumberTests = testList "invalid coordination numbers" [
                   |> Expect.throwsWithType<FormatException>
                   |> Expect.throwsWithMessage "String was not recognized as a valid IdentityNumber." )
 
-    testProp "invalid num returns parsing error" <| fun (Gen.CoordNum.InvalidNumString str) ->
+    testProp "num with invalid year returns parsing error" <| fun (Gen.CoordNum.NumWithInvalidYear str) ->
         toAction SwedishCoordinationNumber.Parse str
-        |> Expect.throwsWithMessage "String was not recognized as a valid IdentityNumber."
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; "Invalid year" ]
+
+    testProp "num with invalid month returns parsing error" <| fun (Gen.CoordNum.NumWithInvalidMonth str) ->
+        toAction SwedishCoordinationNumber.Parse str
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; " Invalid month for coordination number"]
+
+    testProp "num with invalid day returns parsing error" <| fun (Gen.CoordNum.NumWithInvalidDay str) ->
+        toAction SwedishCoordinationNumber.Parse str
+        |> Expect.throwsWithMessages ["String was not recognized as a valid IdentityNumber."; "Invalid coordination day"]
+
+    testProp "num with invalid individual number returns parsing error" <| fun (Gen.CoordNum.NumWithInvalidIndividualNumber str) ->
+        toAction SwedishCoordinationNumber.Parse str
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; "Invalid individual number" ]
+
+    testProp "num with invalid checksum returns parsing error" <| fun (Gen.CoordNum.NumWithInvalidChecksum str) ->
+        toAction SwedishCoordinationNumber.Parse str
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; "Invalid checksum" ]
 
     testProp "parseInSpecificYear with empty string returns parsing error" <| fun (Gen.EmptyString str, Gen.ValidYear year) ->
         toAction SwedishCoordinationNumber.ParseInSpecificYear (str, year)

--- a/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_Parse.fs
+++ b/test/ActiveLogin.Identity.Swedish.FSharp.Test/SwedishPersonalIdentityNumber_Parse.fs
@@ -109,10 +109,25 @@ let invalidPinTests = testList "invalid pins" [
                   |> Expect.throwsWithType<FormatException>
                   |> Expect.throwsWithMessage "String was not recognized as a valid IdentityNumber." )
 
-    testProp "invalid pin returns throws" <| fun (Gen.Pin.InvalidPinString str) ->
+    testProp "pin with invalid year returns parsing error" <| fun (Gen.Pin.PinWithInvalidYear str) ->
         toAction SwedishPersonalIdentityNumber.Parse str
-        |> Expect.throwsWithType<FormatException>
-        |> Expect.throwsWithMessage "String was not recognized as a valid IdentityNumber."
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; "Invalid year" ]
+
+    testProp "pin with invalid month returns parsing error" <| fun (Gen.Pin.PinWithInvalidMonth str) ->
+        toAction SwedishPersonalIdentityNumber.Parse str
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; " Invalid month"]
+
+    testProp "pin with invalid day returns parsing error" <| fun (Gen.Pin.PinWithInvalidDay str) ->
+        toAction SwedishPersonalIdentityNumber.Parse str
+        |> Expect.throwsWithMessages ["String was not recognized as a valid IdentityNumber."; "Invalid day"]
+
+    testProp "pin with invalid individual number returns parsing error" <| fun (Gen.Pin.PinWithInvalidIndividualNumber str) ->
+        toAction SwedishPersonalIdentityNumber.Parse str
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; "Invalid birth number" ]
+
+    testProp "pin with invalid checksum returns parsing error" <| fun (Gen.Pin.PinWithInvalidChecksum str) ->
+        toAction SwedishPersonalIdentityNumber.Parse str
+        |> Expect.throwsWithMessages [ "String was not recognized as a valid IdentityNumber."; "Invalid checksum" ]
 
     testProp "parseInSpecificYear with empty string throws" <| fun (Gen.EmptyString str, Gen.ValidYear year) ->
         toAction SwedishPersonalIdentityNumber.ParseInSpecificYear (str, year)


### PR DESCRIPTION
This PR fixes a bug where we were using 0 instead of the offset 60 when checking if a coordination number is valid.

This condition previously slipped through our tests because we had combined all tests for invalidStrings into one FsCheck generator. This meant that this condition occurred too rarely to be effectively be found within the default number of tests (=200). 

To remedy this, this PR also splits the generator (and consequently the tests) for invalidString into a generator/test for each number part (year, month, day, individual number and checksum). 

This should fix the issue with "rare" occurences of invalid strings, and has the added benefit of making it possible to verify the ParsingErrorMessage more precisely. Before we only checked for "string was not recognized as a valid IdentityNumber", but know we can also check that the message the actual part that failed (e.g. "Invalid year", Invalid checksum").